### PR TITLE
Add "new" Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ cpx gives you multiple ways to run PHP code quickly, perfect for running scratch
 - `cpx exec -r <raw php code>` will execute the given PHP code.
 - `cpx tinker` will open an interactive REPL in the terminal for your project.
 
+### cpx new
+
+`cpx new <vendor>/<package> <project-name>` or `cpx new <vendor>/<package>:<version> <project-name>` will create a new project from the specified package. This is useful for quickly creating a new project without needing to install the package globally.
+
 When using these commands, you get the following benefits:
 
 - **Automatic Autoloaders** - When running a PHP file, it will automatically detect and use Composer's autoloader if it exists in the current or a parent directory

--- a/cpx
+++ b/cpx
@@ -15,6 +15,7 @@ use Cpx\Commands\FormatCommand;
 use Cpx\Commands\TinkerCommand;
 use Cpx\Commands\UpdateCommand;
 use Cpx\Commands\AliasesCommand;
+use Cpx\Commands\NewCommand;
 use Cpx\Commands\UpgradeCommand;
 use Cpx\Commands\VersionCommand;
 
@@ -55,6 +56,7 @@ $command = match (true) {
     $console->command === 'test' => TestCommand::class,
     $console->command === 'tinker' => TinkerCommand::class,
     $console->command === 'version' => VersionCommand::class,
+    $console->command === 'new' => NewCommand::class,
     file_exists(realpath($console->command)) && !is_dir(realpath($console->command)) => (new ExecCommand(Console::parse("exec {$console->command} {$console->getCommandInput()}")))(),
     array_key_exists($console->command, PackageAliases::$packages) => Package::parse(PackageAliases::$packages[$console->command]['package'])->runCommand($console),
     str_contains($console->command, '/') => Package::parse($console->command)->runCommand($console),

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -12,19 +12,20 @@ class HelpCommand extends Command
 
         $this->success('cpx - A Composer package runner with on-demand execution and package management.');
         $this->line('Usage:');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx <vendor/package[:version]> [args]   ' . Command::COLOR_RESET . 'Run a Composer package\'s bin command');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx check                               ' . Command::COLOR_RESET . 'Run a static analysis tool over a project');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx test                                ' . Command::COLOR_RESET . 'Run a testing framework over a project');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx format                              ' . Command::COLOR_RESET . 'Run a code formatter over a project');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx update                              ' . Command::COLOR_RESET . 'Update all packages');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx update <vendor/package>             ' . Command::COLOR_RESET . 'Update all versions of a package');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx clean                               ' . Command::COLOR_RESET . 'Clean unused packages (older than 30 days)');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx clean --all                         ' . Command::COLOR_RESET . 'Clean all packages');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx exec </path/to/php/file.php>        ' . Command::COLOR_RESET . 'Invoke a PHP file');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx exec -r <code>                      ' . Command::COLOR_RESET . 'Run PHP code without <?php ?> tags');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx tinker                              ' . Command::COLOR_RESET . 'Open an interactive REPL');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx list                                ' . Command::COLOR_RESET . 'List all installed packages');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx aliases                             ' . Command::COLOR_RESET . 'Show aliased package names to run via `cpx <alias>`');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx help                                ' . Command::COLOR_RESET . 'Show this help message');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx <vendor/package[:version]> [args]                      ' . Command::COLOR_RESET . 'Run a Composer package\'s bin command');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx new <vendor/package[:version]> <project-name> [args]   ' . Command::COLOR_RESET . 'Create a new project from a Composer package');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx check                                                  ' . Command::COLOR_RESET . 'Run a static analysis tool over a project');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx test                                                   ' . Command::COLOR_RESET . 'Run a testing framework over a project');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx format                                                 ' . Command::COLOR_RESET . 'Run a code formatter over a project');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx update                                                 ' . Command::COLOR_RESET . 'Update all packages');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx update <vendor/package>                                ' . Command::COLOR_RESET . 'Update all versions of a package');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx clean                                                  ' . Command::COLOR_RESET . 'Clean unused packages (older than 30 days)');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx clean --all                                            ' . Command::COLOR_RESET . 'Clean all packages');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx exec </path/to/php/file.php>                           ' . Command::COLOR_RESET . 'Invoke a PHP file');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx exec -r <code>                                         ' . Command::COLOR_RESET . 'Run PHP code without <?php ?> tags');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx tinker                                                 ' . Command::COLOR_RESET . 'Open an interactive REPL');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx list                                                   ' . Command::COLOR_RESET . 'List all installed packages');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx aliases                                                ' . Command::COLOR_RESET . 'Show aliased package names to run via `cpx <alias>`');
+        $this->line('  ' . Command::COLOR_GREEN . 'cpx help                                                   ' . Command::COLOR_RESET . 'Show this help message');
     }
 }

--- a/src/Commands/NewCommand.php
+++ b/src/Commands/NewCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Commands;
+
+use Cpx\Package;
+
+class NewCommand extends Command
+{
+    public function __invoke()
+    {
+        $console = $this->console;
+
+        if (count($console->arguments) < 1) {
+            throw new \Exception("No package name provided.");
+        }
+        if (count($console->arguments) < 2) {
+            throw new \Exception("No directory provided.");
+        }
+
+        $str = $console->arguments[0];
+        if (!str_contains($str, '/')) {
+            throw new \Exception("Invalid package name: {$str}");
+        }
+
+        $package = Package::parse($str);
+
+        $installDir = $package->installOrUpdatePackage();
+
+        $config = [
+            "type" => "path",
+            "url" => "{$installDir}/vendor/{$package->vendor}/{$package->name}",
+            "options" => [
+                "symlink" => false
+            ]
+        ];
+
+        $projectDir = getcwd() . '/' . $console->arguments[1];
+
+        $command = "composer create-project $package->vendor/$package->name --stability=dev --repository='" . json_encode($config) . "' $projectDir";
+        foreach ($console->options as $key => $value) {
+            if ($key === 'repo') {
+                continue;
+            }
+            $command .= " --$key=$value";
+        }
+
+        $descriptorspec = [STDIN, STDOUT, STDOUT];
+        $proc = proc_open($command, $descriptorspec, $pipes);
+        proc_close($proc);
+    }
+}


### PR DESCRIPTION
This command allows you to create a new project using cpx. We have a couple different repos for bootstrapping projects, so this makes it pretty easy to quickly scaffold a new project from them.

- `cpx new laravel/laravel project` or `cpx new laravel/laravel:^11.0 project`

- `cpx new craftcms/craft project`

- `cpx new symfony/skeleton project`