### PR TITLE
add nullable setting for PHP8.4

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -6,7 +6,7 @@ use Exception;
 
 class Composer
 {
-    public static function runCommand(string $command, string $directory = null): array
+    public static function runCommand(string $command, ?string $directory = null): array
     {
         $output = [];
         $workingDirectory = $directory ? "--working-dir={$directory}" : '';


### PR DESCRIPTION
To avoid below message
`Deprecated: Cpx\Composer::runCommand(): Implicitly marking parameter $directory as nullable is deprecated, the explicit nullable type must be used instead in /Users/xxxx/projects/cpx/src/Composer.php on line 9
`