### PR TITLE
Add package quality tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,53 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+      - 1.x
+      - 2.x
+  pull_request:
+    branches:
+      - main
+      - 1.x
+      - 2.x
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.3', '8.4', '8.5']
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run Static Analysis
+        run: composer analyse
+
+      - name: Run Lint Check
+        run: composer lint:check
+
+      - name: Run Type Coverage
+        run: composer test:types
+
+      - name: Run Unit Tests
+        run: composer test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "php": "^8.2"
     },
     "require-dev": {
+        "laravel/pao": "^1.1",
         "laravel/pint": "^1.29",
         "phpstan/phpstan": "^2.2"
     },
@@ -52,5 +53,8 @@
             "@analyse",
             "@lint:check"
         ]
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,18 @@
             "src/functions.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": "^8.2"
     },
     "require-dev": {
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.29",
+        "pestphp/pest": "^4.7",
         "phpstan/phpstan": "^2.2"
     },
     "bin": [
@@ -49,12 +55,19 @@
         "lint:check": [
             "pint --parallel --test"
         ],
+        "test:unit": [
+            "pest --parallel"
+        ],
         "test": [
             "@analyse",
-            "@lint:check"
+            "@lint:check",
+            "@test:unit"
         ]
     },
     "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        },
         "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,21 @@
     "require": {
         "php": "^8.2"
     },
+    "require-dev": {
+        "laravel/pint": "^1.27"
+    },
     "bin": [
         "cpx"
-    ]
+    ],
+    "scripts": {
+        "lint": [
+            "pint --parallel"
+        ],
+        "lint:check": [
+            "pint --parallel --test"
+        ],
+        "test": [
+            "@lint:check"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,16 @@
         "php": "^8.2"
     },
     "require-dev": {
-        "laravel/pint": "^1.27"
+        "laravel/pint": "^1.29",
+        "phpstan/phpstan": "^2.2"
     },
     "bin": [
         "cpx"
     ],
     "scripts": {
+        "analyse": [
+            "phpstan analyse"
+        ],
         "lint": [
             "pint --parallel"
         ],
@@ -45,6 +49,7 @@
             "pint --parallel --test"
         ],
         "test": [
+            "@analyse",
             "@lint:check"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.29",
         "pestphp/pest": "^4.7",
+        "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan": "^2.2"
     },
     "bin": [
@@ -55,12 +56,16 @@
         "lint:check": [
             "pint --parallel --test"
         ],
+        "test:types": [
+            "pest --type-coverage --min=100"
+        ],
         "test:unit": [
             "pest --parallel"
         ],
         "test": [
             "@analyse",
             "@lint:check",
+            "@test:types",
             "@test:unit"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "require": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "require-dev": {
         "laravel/pao": "^1.1",

--- a/cpx
+++ b/cpx
@@ -34,11 +34,6 @@ if (isset($GLOBALS['_composer_autoload_path'])) {
     unset($file);
 }
 
-function printColor(string $message, string $color = "\033[1;32m"): void
-{
-    echo $color . $message . "\033[0m" . PHP_EOL;
-}
-
 array_shift($argv);
 $console = Console::parse($argv ?? []);
 

--- a/files/psysh-config.php
+++ b/files/psysh-config.php
@@ -1,7 +1,9 @@
 <?php
 
-require_once __DIR__ . '/../vendor/autoload.php';
+use Cpx\PhpExecutionHelper;
 
-Cpx\PhpExecutionHelper::init(getcwd());
+require_once __DIR__.'/../vendor/autoload.php';
+
+PhpExecutionHelper::init(getcwd());
 
 return [];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: 7
+    paths:
+        - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,8 +11,7 @@
     </testsuites>
     <source>
         <include>
-            <directory>app</directory>
-            <directory>src</directory>
+            <directory suffix=".php">src</directory>
         </include>
     </source>
 </phpunit>

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,27 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "blank_line_before_statement": {
+            "statements": [
+                "break",
+                "continue",
+                "declare",
+                "if",
+                "return",
+                "throw",
+                "try"
+            ]
+        },
+        "global_namespace_import": {
+            "import_classes": true
+        },
+        "trailing_comma_in_multiline": {
+            "elements": [
+                "arguments",
+                "arrays",
+                "match",
+                "parameters"
+            ]
+        }
+    }
+}

--- a/src/ClassAliasAutoloader.php
+++ b/src/ClassAliasAutoloader.php
@@ -8,7 +8,7 @@ use SplFileInfo;
 
 class ClassAliasAutoloader
 {
-    /** All of the discovered classes. */
+    /** @var array<string, string> */
     protected array $classes = [];
 
     public function __construct(

--- a/src/ClassAliasAutoloader.php
+++ b/src/ClassAliasAutoloader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 use RecursiveDirectoryIterator;

--- a/src/ClassAliasAutoloader.php
+++ b/src/ClassAliasAutoloader.php
@@ -2,8 +2,8 @@
 
 namespace Cpx;
 
-use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use SplFileInfo;
 
 class ClassAliasAutoloader
@@ -21,13 +21,13 @@ class ClassAliasAutoloader
             $classes = require "{$autoloadRootDirectory}/vendor/composer/autoload_classmap.php";
 
             foreach ($classes as $class => $path) {
-                if (!str_contains($class, '\\')) {
+                if (! str_contains($class, '\\')) {
                     continue;
                 }
 
                 $name = basename(str_replace('\\', '/', $class));
 
-                if (!isset($this->classes[$name]) && class_exists($name)) {
+                if (! isset($this->classes[$name]) && class_exists($name)) {
                     $this->classes[$name] = $class;
                 }
             }
@@ -38,12 +38,12 @@ class ClassAliasAutoloader
 
             foreach ($psr4 as $namespace => $directories) {
                 foreach ($directories as $directory) {
-                    if (!file_exists($directory)) {
+                    if (! file_exists($directory)) {
                         continue;
                     }
                     $iterator = new RecursiveIteratorIterator(
                         new RecursiveDirectoryIterator($directory),
-                        RecursiveIteratorIterator::LEAVES_ONLY
+                        RecursiveIteratorIterator::LEAVES_ONLY,
                     );
 
                     foreach ($iterator as $file) {
@@ -53,13 +53,12 @@ class ClassAliasAutoloader
 
                             $relativePath = str_replace($directory, '', $file->getPath());
 
-                            if (!empty($relativePath)) {
-                                $classNamespace .= strtr($relativePath, DIRECTORY_SEPARATOR, '\\') . '\\';
+                            if (! empty($relativePath)) {
+                                $classNamespace .= strtr($relativePath, DIRECTORY_SEPARATOR, '\\').'\\';
                             }
 
                             $basename = $file->getBasename('.php');
-                            $class = str_replace('\\\\', '\\', $classNamespace . $basename);
-
+                            $class = str_replace('\\\\', '\\', $classNamespace.$basename);
 
                             if (str_ends_with($basename, 'Test')) {
                                 continue;

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -12,7 +12,7 @@ class AliasesCommand extends Command
     {
         $this->line('Aliased packages:'.PHP_EOL);
         $packages = PackageAliases::$packages;
-        usort($packages, fn ($a, $b) => strcmp($a['command'], $b['command']));
+        usort($packages, fn (array $a, array $b): int => strcmp($a['command'], $b['command']));
 
         foreach ($packages as $package) {
             $paddedCommand = str_pad($package['command'], 15);

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\PackageAliases;

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -6,7 +6,7 @@ use Cpx\PackageAliases;
 
 class AliasesCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         $this->line('Aliased packages:'.PHP_EOL);
         $packages = PackageAliases::$packages;

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -8,13 +8,13 @@ class AliasesCommand extends Command
 {
     public function __invoke()
     {
-        $this->line('Aliased packages:' . PHP_EOL);
+        $this->line('Aliased packages:'.PHP_EOL);
         $packages = PackageAliases::$packages;
         usort($packages, fn ($a, $b) => strcmp($a['command'], $b['command']));
 
         foreach ($packages as $package) {
             $paddedCommand = str_pad($package['command'], 15);
-            $this->line('  ' . Command::COLOR_GREEN . 'cpx ' . $paddedCommand . Command::COLOR_RESET . '   ' . $package['description']);
+            $this->line('  '.Command::COLOR_GREEN.'cpx '.$paddedCommand.Command::COLOR_RESET.'   '.$package['description']);
         }
     }
 }

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Console;

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -7,24 +7,30 @@ use Cpx\Exceptions\ConsoleException;
 
 class CheckCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         if (file_exists('vendor/bin/phpstan')) {
             $command = 'vendor/bin/phpstan analyse';
 
-            return Console::parse($command)->exec();
+            Console::parse($command)->exec();
+
+            return;
         }
 
         if (file_exists('vendor/bin/psalm')) {
             $command = 'vendor/bin/psalm';
 
-            return Console::parse($command)->exec();
+            Console::parse($command)->exec();
+
+            return;
         }
 
         if (file_exists('vendor/bin/phan')) {
             $command = 'vendor/bin/phan';
 
-            return Console::parse($command)->exec();
+            Console::parse($command)->exec();
+
+            return;
         }
 
         throw new ConsoleException('No static analyzers found in the project.');

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -2,8 +2,8 @@
 
 namespace Cpx\Commands;
 
-use Cpx\Package;
 use Cpx\Metadata;
+use Cpx\Package;
 
 class CleanCommand extends Command
 {
@@ -20,7 +20,7 @@ class CleanCommand extends Command
 
             if ($this->console->hasOption('all') || $lastRun < $timeLimit) {
                 $package = Package::parse($packageKey);
-                $this->line(Command::COLOR_GREEN . "Removing unused package {$package}...");
+                $this->line(Command::COLOR_GREEN."Removing unused package {$package}...");
                 $package->delete();
                 unset($metadata->packages[$packageKey]);
                 $cleanedSomething = true;
@@ -33,7 +33,7 @@ class CleanCommand extends Command
             if ($this->console->hasOption('all') || $lastRun < $timeLimit) {
                 $packageDirectory = cpx_path(".exec_cache/{$sandboxDir}");
                 exec("rm -rf {$packageDirectory}");
-                $this->line(Command::COLOR_GREEN . "Removing exec sandbox cache {$sandboxDir}...");
+                $this->line(Command::COLOR_GREEN."Removing exec sandbox cache {$sandboxDir}...");
                 unset($metadata->execCache[$sandboxDir]);
                 $cleanedSomething = true;
             }
@@ -41,8 +41,8 @@ class CleanCommand extends Command
 
         $metadata->save();
 
-        if (!$cleanedSomething) {
-            $this->success("There were no packages to clean.");
+        if (! $cleanedSomething) {
+            $this->success('There were no packages to clean.');
         }
     }
 }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -7,7 +7,7 @@ use Cpx\Package;
 
 class CleanCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         $days = (int) ($this->console->getOption('days') ?? 30);
 
@@ -28,7 +28,7 @@ class CleanCommand extends Command
         }
 
         foreach ($metadata->execCache as $sandboxDir => $packageMetadata) {
-            $lastRun = strtotime($packageMetadata->lastRunAt ?? '1970-01-01 00:00:00');
+            $lastRun = $packageMetadata['last_run'] ?? 0;
 
             if ($this->console->hasOption('all') || $lastRun < $timeLimit) {
                 $packageDirectory = cpx_path(".exec_cache/{$sandboxDir}");

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Metadata;
 use Cpx\Package;
+use Cpx\Utils;
 
 class CleanCommand extends Command
 {
@@ -32,7 +35,7 @@ class CleanCommand extends Command
 
             if ($this->console->hasOption('all') || $lastRun < $timeLimit) {
                 $packageDirectory = cpx_path(".exec_cache/{$sandboxDir}");
-                exec("rm -rf {$packageDirectory}");
+                Utils::deleteDirectory($packageDirectory);
                 $this->line(Command::COLOR_GREEN."Removing exec sandbox cache {$sandboxDir}...");
                 unset($metadata->execCache[$sandboxDir]);
                 $cleanedSomething = true;

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Console;

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -9,21 +9,31 @@ abstract class Command
     public const COLOR_RESET = "\033[0m";
 
     public const COLOR_GREEN = "\033[1;32m";
+
     public const COLOR_RED = "\033[1;31m";
+
     public const COLOR_YELLOW = "\033[1;33m";
+
     public const COLOR_BLUE = "\033[1;34m";
+
     public const COLOR_MAGENTA = "\033[1;35m";
+
     public const COLOR_CYAN = "\033[1;36m";
 
     public const BACKGROUND_GREEN = "\033[42m";
+
     public const BACKGROUND_RED = "\033[41m";
+
     public const BACKGROUND_YELLOW = "\033[43m";
+
     public const BACKGROUND_BLUE = "\033[44m";
+
     public const BACKGROUND_MAGENTA = "\033[45m";
+
     public const BACKGROUND_CYAN = "\033[46m";
 
     public function __construct(
-        protected Console $console
+        protected Console $console,
     ) {}
 
     protected function line(string $message, string $color = Command::COLOR_RESET): void
@@ -32,13 +42,13 @@ abstract class Command
         $padding = str_repeat(' ', $isBackgroundColor ? 3 : 0);
 
         if ($isBackgroundColor) {
-            echo $color . str_repeat(' ', mb_strlen($message) + (strlen($padding) * 2)) . Command::COLOR_RESET . PHP_EOL;
+            echo $color.str_repeat(' ', mb_strlen($message) + (strlen($padding) * 2)).Command::COLOR_RESET.PHP_EOL;
         }
 
-        echo $color . $padding . $message . $padding . Command::COLOR_RESET . PHP_EOL;
+        echo $color.$padding.$message.$padding.Command::COLOR_RESET.PHP_EOL;
 
         if ($isBackgroundColor) {
-            echo $color . str_repeat(' ', mb_strlen($message) + (strlen($padding) * 2)) . Command::COLOR_RESET . PHP_EOL;
+            echo $color.str_repeat(' ', mb_strlen($message) + (strlen($padding) * 2)).Command::COLOR_RESET.PHP_EOL;
             echo PHP_EOL;
         }
     }

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\PhpExecutionHelper;

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -2,7 +2,6 @@
 
 namespace Cpx\Commands;
 
-use Cpx\ClassAliasAutoloader;
 use Cpx\PhpExecutionHelper;
 
 class ExecCommand extends Command
@@ -16,6 +15,7 @@ class ExecCommand extends Command
 
             if (empty($code)) {
                 $this->error('Please supply code to execute with the -r option.');
+
                 return;
             }
 
@@ -27,7 +27,7 @@ class ExecCommand extends Command
                 }
             }
 
-            if (!str_ends_with(trim($code), ';')) {
+            if (! str_ends_with(trim($code), ';')) {
                 $code .= ';';
             }
 
@@ -41,13 +41,15 @@ class ExecCommand extends Command
 
         if (empty($this->console->arguments[0])) {
             $this->error('Please supply the path to a file to execute.');
+
             return;
         }
 
         $this->path = realpath($this->console->arguments[0]);
 
-        if (!file_exists($this->path)) {
+        if (! file_exists($this->path)) {
             $this->error("File does not exist at '{$this->path}'");
+
             return;
         }
 

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -8,7 +8,7 @@ class ExecCommand extends Command
 {
     public string $path;
 
-    public function __invoke()
+    public function __invoke(): void
     {
         if ($this->console->hasOption('r')) {
             $code = $this->console->getOption('r');
@@ -31,7 +31,15 @@ class ExecCommand extends Command
                 $code .= ';';
             }
 
-            $this->autoload(getcwd());
+            $directory = getcwd();
+
+            if ($directory === false) {
+                $this->error('Unable to determine the current working directory.');
+
+                return;
+            }
+
+            $this->autoload($directory);
 
             eval($code);
             echo PHP_EOL;
@@ -45,13 +53,15 @@ class ExecCommand extends Command
             return;
         }
 
-        $this->path = realpath($this->console->arguments[0]);
+        $path = realpath($this->console->arguments[0]);
 
-        if (! file_exists($this->path)) {
-            $this->error("File does not exist at '{$this->path}'");
+        if ($path === false || ! file_exists($path)) {
+            $this->error("File does not exist at '{$this->console->arguments[0]}'");
 
             return;
         }
+
+        $this->path = $path;
 
         $this->autoload(dirname($this->path));
 
@@ -60,12 +70,23 @@ class ExecCommand extends Command
 
     protected function autoload(string $directory): void
     {
-        $shouldFindAutoloader = $this->console->getOption('find-autoloader') ?? true;
-        $shouldLoadLaravelBootstrap = $this->console->getOption('load-laravel-bootstrap') ?? true;
-        $shouldAliasClasses = $this->console->getOption('alias-classes') ?? true;
-        $shouldBeVerbose = $this->console->getOption('verbose') ?? false;
+        $shouldFindAutoloader = $this->booleanOption('find-autoloader', true);
+        $shouldLoadLaravelBootstrap = $this->booleanOption('load-laravel-bootstrap', true);
+        $shouldAliasClasses = $this->booleanOption('alias-classes', true);
+        $shouldBeVerbose = $this->booleanOption('verbose', false);
 
         PhpExecutionHelper::init($directory, $shouldFindAutoloader, $shouldLoadLaravelBootstrap, $shouldAliasClasses, $shouldBeVerbose);
+    }
+
+    protected function booleanOption(string $option, bool $default): bool
+    {
+        $value = $this->console->getOption($option);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
     }
 
     public function runFile(): void

--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Console;

--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -7,7 +7,7 @@ use Cpx\Exceptions\ConsoleException;
 
 class FormatCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         $directory = $this->console->arguments[0] ?? '.';
 
@@ -18,7 +18,9 @@ class FormatCommand extends Command
                 $command .= ' --test';
             }
 
-            return Console::parse($command)->exec();
+            Console::parse($command)->exec();
+
+            return;
         }
 
         if (file_exists('vendor/bin/php-cs-fixer')) {
@@ -30,13 +32,17 @@ class FormatCommand extends Command
 
             $command .= ' --allow-risky=yes';
 
-            return Console::parse($command)->exec();
+            Console::parse($command)->exec();
+
+            return;
         }
 
         if (file_exists('vendor/bin/phpcbf')) {
             $command = "vendor/bin/phpcbf {$directory}";
 
-            return Console::parse($command)->exec();
+            Console::parse($command)->exec();
+
+            return;
         }
 
         throw new ConsoleException('No code formatters found in the project.');

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -4,7 +4,7 @@ namespace Cpx\Commands;
 
 class HelpCommand extends Command
 {
-    public function __invoke(bool $unknownCommand = false)
+    public function __invoke(bool $unknownCommand = false): void
     {
         if ($unknownCommand) {
             $this->error("Unrecognised command {$this->console->command}");

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -12,19 +12,19 @@ class HelpCommand extends Command
 
         $this->success('cpx - A Composer package runner with on-demand execution and package management.');
         $this->line('Usage:');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx <vendor/package[:version]> [args]   ' . Command::COLOR_RESET . 'Run a Composer package\'s bin command');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx check                               ' . Command::COLOR_RESET . 'Run a static analysis tool over a project');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx test                                ' . Command::COLOR_RESET . 'Run a testing framework over a project');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx format                              ' . Command::COLOR_RESET . 'Run a code formatter over a project');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx update                              ' . Command::COLOR_RESET . 'Update all packages');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx update <vendor/package>             ' . Command::COLOR_RESET . 'Update all versions of a package');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx clean                               ' . Command::COLOR_RESET . 'Clean unused packages (older than 30 days)');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx clean --all                         ' . Command::COLOR_RESET . 'Clean all packages');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx exec </path/to/php/file.php>        ' . Command::COLOR_RESET . 'Invoke a PHP file');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx exec -r <code>                      ' . Command::COLOR_RESET . 'Run PHP code without <?php ?> tags');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx tinker                              ' . Command::COLOR_RESET . 'Open an interactive REPL');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx list                                ' . Command::COLOR_RESET . 'List all installed packages');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx aliases                             ' . Command::COLOR_RESET . 'Show aliased package names to run via `cpx <alias>`');
-        $this->line('  ' . Command::COLOR_GREEN . 'cpx help                                ' . Command::COLOR_RESET . 'Show this help message');
+        $this->line('  '.Command::COLOR_GREEN.'cpx <vendor/package[:version]> [args]   '.Command::COLOR_RESET.'Run a Composer package\'s bin command');
+        $this->line('  '.Command::COLOR_GREEN.'cpx check                               '.Command::COLOR_RESET.'Run a static analysis tool over a project');
+        $this->line('  '.Command::COLOR_GREEN.'cpx test                                '.Command::COLOR_RESET.'Run a testing framework over a project');
+        $this->line('  '.Command::COLOR_GREEN.'cpx format                              '.Command::COLOR_RESET.'Run a code formatter over a project');
+        $this->line('  '.Command::COLOR_GREEN.'cpx update                              '.Command::COLOR_RESET.'Update all packages');
+        $this->line('  '.Command::COLOR_GREEN.'cpx update <vendor/package>             '.Command::COLOR_RESET.'Update all versions of a package');
+        $this->line('  '.Command::COLOR_GREEN.'cpx clean                               '.Command::COLOR_RESET.'Clean unused packages (older than 30 days)');
+        $this->line('  '.Command::COLOR_GREEN.'cpx clean --all                         '.Command::COLOR_RESET.'Clean all packages');
+        $this->line('  '.Command::COLOR_GREEN.'cpx exec </path/to/php/file.php>        '.Command::COLOR_RESET.'Invoke a PHP file');
+        $this->line('  '.Command::COLOR_GREEN.'cpx exec -r <code>                      '.Command::COLOR_RESET.'Run PHP code without <?php ?> tags');
+        $this->line('  '.Command::COLOR_GREEN.'cpx tinker                              '.Command::COLOR_RESET.'Open an interactive REPL');
+        $this->line('  '.Command::COLOR_GREEN.'cpx list                                '.Command::COLOR_RESET.'List all installed packages');
+        $this->line('  '.Command::COLOR_GREEN.'cpx aliases                             '.Command::COLOR_RESET.'Show aliased package names to run via `cpx <alias>`');
+        $this->line('  '.Command::COLOR_GREEN.'cpx help                                '.Command::COLOR_RESET.'Show this help message');
     }
 }

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 class HelpCommand extends Command

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -6,7 +6,7 @@ use Cpx\Metadata;
 
 class ListCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         $metadata = Metadata::open();
 

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Metadata;
@@ -12,7 +14,8 @@ class ListCommand extends Command
 
         if (empty($metadata->packages)) {
             $this->line('There are no installed packages.');
-            exit();
+
+            return;
         }
 
         $this->line('Installed Packages:');

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -9,6 +9,7 @@ class ListCommand extends Command
     public function __invoke()
     {
         $metadata = Metadata::open();
+
         if (empty($metadata->packages)) {
             $this->line('There are no installed packages.');
             exit();
@@ -17,7 +18,7 @@ class ListCommand extends Command
         $this->line('Installed Packages:');
 
         foreach ($metadata->packages as $packageKey => $packageMetadata) {
-            $this->line(Command::COLOR_GREEN . "  {$packageMetadata->package->fullPackageString()}" . Command::COLOR_RESET . ' (Last Run: ' . ($packageMetadata->lastRunAt ?? 'N/A') . ')');
+            $this->line(Command::COLOR_GREEN."  {$packageMetadata->package->fullPackageString()}".Command::COLOR_RESET.' (Last Run: '.($packageMetadata->lastRunAt ?? 'N/A').')');
         }
     }
 }

--- a/src/Commands/RunPackageCommand.php
+++ b/src/Commands/RunPackageCommand.php
@@ -4,5 +4,5 @@ namespace Cpx\Commands;
 
 class RunPackageCommand extends Command
 {
-    public function __invoke() {}
+    public function __invoke(): void {}
 }

--- a/src/Commands/RunPackageCommand.php
+++ b/src/Commands/RunPackageCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 class RunPackageCommand extends Command

--- a/src/Commands/RunPackageCommand.php
+++ b/src/Commands/RunPackageCommand.php
@@ -4,7 +4,5 @@ namespace Cpx\Commands;
 
 class RunPackageCommand extends Command
 {
-    public function __invoke()
-    {
-    }
+    public function __invoke() {}
 }

--- a/src/Commands/TestCommand.php
+++ b/src/Commands/TestCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Console;

--- a/src/Commands/TestCommand.php
+++ b/src/Commands/TestCommand.php
@@ -4,7 +4,6 @@ namespace Cpx\Commands;
 
 use Cpx\Console;
 use Cpx\Exceptions\ConsoleException;
-use Exception;
 
 class TestCommand extends Command
 {

--- a/src/Commands/TestCommand.php
+++ b/src/Commands/TestCommand.php
@@ -7,22 +7,30 @@ use Cpx\Exceptions\ConsoleException;
 
 class TestCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         if (file_exists('vendor/bin/pest')) {
-            return Console::parse('vendor/bin/pest')->exec();
+            Console::parse('vendor/bin/pest')->exec();
+
+            return;
         }
 
         if (file_exists('bin/phpunit')) {
-            return Console::parse('bin/phpunit')->exec();
+            Console::parse('bin/phpunit')->exec();
+
+            return;
         }
 
         if (file_exists('vendor/bin/phpunit')) {
-            return Console::parse('vendor/bin/phpunit')->exec();
+            Console::parse('vendor/bin/phpunit')->exec();
+
+            return;
         }
 
         if (file_exists('vendor/bin/codecept')) {
-            return Console::parse('vendor/bin/codecept')->exec();
+            Console::parse('vendor/bin/codecept')->exec();
+
+            return;
         }
 
         throw new ConsoleException('No test runner found in the project.');

--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Console;

--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -7,10 +7,16 @@ use Cpx\Package;
 
 class TinkerCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         $psyshConfig = realpath(__DIR__.'/../../files/psysh-config.php');
 
-        return Package::parse('psy/psysh')->runCommand(Console::parse("psysh --config {$psyshConfig}"));
+        if ($psyshConfig === false) {
+            $this->error('Unable to find the PsySH configuration file.');
+
+            return;
+        }
+
+        Package::parse('psy/psysh')->runCommand(Console::parse("psysh --config {$psyshConfig}"));
     }
 }

--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -4,14 +4,12 @@ namespace Cpx\Commands;
 
 use Cpx\Console;
 use Cpx\Package;
-use Cpx\Commands\Command;
-use Cpx\Composer;
 
 class TinkerCommand extends Command
 {
     public function __invoke()
     {
-        $psyshConfig = realpath(__DIR__ . '/../../files/psysh-config.php');
+        $psyshConfig = realpath(__DIR__.'/../../files/psysh-config.php');
 
         return Package::parse('psy/psysh')->runCommand(Console::parse("psysh --config {$psyshConfig}"));
     }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -7,7 +7,7 @@ use Cpx\Package;
 
 class UpdateCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         match (true) {
             str_contains($this->console->arguments[0] ?? '', '/') => $this->updatePackage(Package::parse($this->console->arguments[0])),

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -9,9 +9,9 @@ class UpdateCommand extends Command
 {
     public function __invoke()
     {
-        match(true) {
+        match (true) {
             str_contains($this->console->arguments[0] ?? '', '/') => $this->updatePackage(Package::parse($this->console->arguments[0])),
-            !empty($this->console->arguments[0]) => $this->updateVendor($this->console->arguments[0]),
+            ! empty($this->console->arguments[0]) => $this->updateVendor($this->console->arguments[0]),
             default => $this->updateAllPackages(),
         };
     }
@@ -63,7 +63,7 @@ class UpdateCommand extends Command
 
     protected function updateDirectory(string $directory): void
     {
-        $this->line('Updating ' . Command::COLOR_GREEN . str_replace(cpx_path(), '', $directory));
-        Composer::runCommand("update", $directory);
+        $this->line('Updating '.Command::COLOR_GREEN.str_replace(cpx_path(), '', $directory));
+        Composer::runCommand('update', $directory);
     }
 }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Composer;

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Commands;
 
 use Cpx\Composer;

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -6,7 +6,7 @@ use Cpx\Composer;
 
 class UpgradeCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
         $this->line('Updating '.Command::COLOR_GREEN.'cpx');
         Composer::runCommand('global update cpx/cpx');

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -8,7 +8,7 @@ class UpgradeCommand extends Command
 {
     public function __invoke()
     {
-        $this->line('Updating ' . Command::COLOR_GREEN . 'cpx');
+        $this->line('Updating '.Command::COLOR_GREEN.'cpx');
         Composer::runCommand('global update cpx/cpx');
     }
 }

--- a/src/Commands/VersionCommand.php
+++ b/src/Commands/VersionCommand.php
@@ -6,9 +6,21 @@ namespace Cpx\Commands;
 
 class VersionCommand extends Command
 {
-    public function __invoke()
+    public function __invoke(): void
     {
-        $cpxVersion = json_decode(file_get_contents(__DIR__.'/../../composer.json'), true)['version'] ?? 'unknown';
+        $contents = file_get_contents(__DIR__.'/../../composer.json');
+        $composerData = [];
+
+        if ($contents !== false) {
+            $decoded = json_decode($contents, true);
+
+            if (is_array($decoded)) {
+                $composerData = $decoded;
+            }
+        }
+
+        $cpxVersion = is_string($composerData['version'] ?? null) ? $composerData['version'] : 'unknown';
+
         $this->line('cpx version: '.Command::COLOR_GREEN.$cpxVersion);
         $this->line('php version: '.Command::COLOR_GREEN.PHP_VERSION);
     }

--- a/src/Commands/VersionCommand.php
+++ b/src/Commands/VersionCommand.php
@@ -8,8 +8,8 @@ class VersionCommand extends Command
 {
     public function __invoke()
     {
-        $cpxVersion = json_decode(file_get_contents(__DIR__ . '/../../composer.json'), true)['version'] ?? 'unknown';
-        $this->line('cpx version: ' . Command::COLOR_GREEN . $cpxVersion);
-        $this->line('php version: ' . Command::COLOR_GREEN . PHP_VERSION);
+        $cpxVersion = json_decode(file_get_contents(__DIR__.'/../../composer.json'), true)['version'] ?? 'unknown';
+        $this->line('cpx version: '.Command::COLOR_GREEN.$cpxVersion);
+        $this->line('php version: '.Command::COLOR_GREEN.PHP_VERSION);
     }
 }

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -6,6 +6,7 @@ use Exception;
 
 class Composer
 {
+    /** @return list<string> */
     public static function runCommand(string $command, ?string $directory = null): array
     {
         $output = [];
@@ -30,9 +31,15 @@ class Composer
         $composerFile = "{$directory}/composer.json";
 
         if (file_exists($composerFile)) {
-            $composerData = json_decode(file_get_contents($composerFile), true);
+            $contents = file_get_contents($composerFile);
 
-            if (isset($composerData['bin'])) {
+            if ($contents === false) {
+                return [];
+            }
+
+            $composerData = json_decode($contents, true);
+
+            if (is_array($composerData) && isset($composerData['bin'])) {
                 return (array) $composerData['bin'];
             }
         }
@@ -45,9 +52,16 @@ class Composer
         $composerLock = "{$directory}/composer.lock";
 
         if (file_exists($composerLock)) {
-            $lockData = json_decode(file_get_contents($composerLock), true);
+            $contents = file_get_contents($composerLock);
 
-            return $lockData['packages'][0]['version'] ?? 'unknown';
+            if ($contents === false) {
+                return 'unknown';
+            }
+
+            $lockData = json_decode($contents, true);
+            $version = is_array($lockData) ? ($lockData['packages'][0]['version'] ?? null) : null;
+
+            return is_string($version) ? $version : 'unknown';
         }
 
         return 'unknown';

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 use Exception;
@@ -9,16 +11,42 @@ class Composer
     /** @return list<string> */
     public static function runCommand(string $command, ?string $directory = null): array
     {
-        $output = [];
         $workingDirectory = $directory ? "--working-dir={$directory}" : '';
+        $process = proc_open(
+            "composer {$command} --no-interaction --quiet {$workingDirectory}",
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+        );
 
-        exec("composer {$command} --no-interaction --quiet {$workingDirectory}", $output, $resultCode);
-
-        if ($resultCode !== 0) {
+        if (! is_resource($process)) {
             throw new Exception("Composer command failed: {$command}");
         }
 
-        return $output;
+        fclose($pipes[0]);
+
+        $output = stream_get_contents($pipes[1]);
+        $errorOutput = stream_get_contents($pipes[2]);
+
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $resultCode = proc_close($process);
+
+        if ($resultCode !== 0) {
+            $message = trim($errorOutput) ?: "Composer command failed: {$command}";
+
+            throw new Exception($message);
+        }
+
+        if ($output === false || trim($output) === '') {
+            return [];
+        }
+
+        return explode(PHP_EOL, trim($output));
     }
 
     /**

--- a/src/Console.php
+++ b/src/Console.php
@@ -8,11 +8,9 @@ use Cpx\Exceptions\ConsoleException;
 class Console
 {
     /**
-     * @param string $rawInput
-     * @param string $command
-     * @param array<int,string> $arguments
-     * @param array<string,string|array<int,string>> $options
-     * @param array<int,string> $flags
+     * @param  array<int,string>  $arguments
+     * @param  array<string,string|array<int,string>>  $options
+     * @param  array<int,string>  $flags
      */
     public function __construct(
         public string $rawInput,
@@ -25,11 +23,9 @@ class Console
     /**
      * Parses $argv to get the command, arguments, options, and flags.
      *
-     * @param string|array $input The $argv variable.
-     * @param array $shortOptions Optional. An array with keys set to short options and their values set to the long option they're assigned to.
-     * @param array $flagOptions Optional. An array of options to be treated as flags. If a flag is not defined here, it will be treated as an option.
-     *
-     * @return Console
+     * @param  string|array  $input  The $argv variable.
+     * @param  array  $shortOptions  Optional. An array with keys set to short options and their values set to the long option they're assigned to.
+     * @param  array  $flagOptions  Optional. An array of options to be treated as flags. If a flag is not defined here, it will be treated as an option.
      */
     public static function parse(string|array $input, $shortOptions = [], $flagOptions = []): Console
     {
@@ -40,7 +36,7 @@ class Console
         if (is_string($input)) {
             $input = trim($input);
             $input = preg_split('/\s+(?=([^"]*"[^"]*")*[^"]*$)/', $input);
-            $input = array_map(function($item) {
+            $input = array_map(function ($item) {
                 return trim($item, '"\'');
             }, $input);
         }
@@ -51,7 +47,7 @@ class Console
         $flags = [];
         $lastOption = null;
 
-        foreach($input as $arg) {
+        foreach ($input as $arg) {
             $value = null;
 
             if (substr($arg, 0, 1) !== '-') {
@@ -61,6 +57,7 @@ class Console
                 } else {
                     $arguments[] = $arg;
                     $lastOption = null;
+
                     continue;
                 }
             } else {
@@ -72,12 +69,13 @@ class Console
                     $value = $arg_split[2];
                 }
             }
+
             if (array_key_exists($arg, $shortOptions)) {
                 $arg = $shortOptions[$arg];
             }
 
             if (in_array($arg, $flagOptions)) {
-                if (!in_array($arg, $flags)) {
+                if (! in_array($arg, $flags)) {
                     $flags[] = $arg;
                 }
 
@@ -89,8 +87,8 @@ class Console
                     } else {
                         if (is_null($options[$arg])) {
                             $options[$arg] = $value;
-                        } elseif (!is_null($value)) {
-                            $options[$arg] = array($options[$arg], $value);
+                        } elseif (! is_null($value)) {
+                            $options[$arg] = [$options[$arg], $value];
                         }
                     }
                 } else {
@@ -101,7 +99,7 @@ class Console
             }
         }
 
-        return new Console(join(' ', $input), $command, $arguments, $options, $flags);
+        return new Console(implode(' ', $input), $command, $arguments, $options, $flags);
     }
 
     public function hasOption(string $option): bool
@@ -131,7 +129,7 @@ class Console
 
     public function getArgumentsString(): string
     {
-        return join(' ', $this->arguments);
+        return implode(' ', $this->arguments);
     }
 
     public function getOptionsString(): string
@@ -139,11 +137,11 @@ class Console
         return implode(' ', array_map(
             function ($key, $value) {
                 return implode(' ', array_map(function ($v) use ($key) {
-                    return $v === null ? "--{$key}" : "--{$key}=" . escapeshellarg($v);
+                    return $v === null ? "--{$key}" : "--{$key}=".escapeshellarg($v);
                 }, $value === null ? [null] : (array) $value));
             },
             array_keys($this->options),
-            $this->options
+            $this->options,
         ));
     }
 
@@ -161,7 +159,7 @@ class Console
         ];
 
         if ($verbose) {
-            echo Command::BACKGROUND_CYAN . "   Running command: '{$this}'   " . Command::COLOR_RESET;
+            echo Command::BACKGROUND_CYAN."   Running command: '{$this}'   ".Command::COLOR_RESET;
         }
 
         $process = proc_open($this, $descriptors, $pipes);

--- a/src/Console.php
+++ b/src/Console.php
@@ -8,9 +8,9 @@ use Cpx\Exceptions\ConsoleException;
 class Console
 {
     /**
-     * @param  array<int,string>  $arguments
-     * @param  array<string,string|array<int,string>>  $options
-     * @param  array<int,string>  $flags
+     * @param  list<string>  $arguments
+     * @param  array<string, string|null|list<string|null>>  $options
+     * @param  list<string>  $flags
      */
     public function __construct(
         public string $rawInput,
@@ -23,11 +23,11 @@ class Console
     /**
      * Parses $argv to get the command, arguments, options, and flags.
      *
-     * @param  string|array  $input  The $argv variable.
-     * @param  array  $shortOptions  Optional. An array with keys set to short options and their values set to the long option they're assigned to.
-     * @param  array  $flagOptions  Optional. An array of options to be treated as flags. If a flag is not defined here, it will be treated as an option.
+     * @param  string|list<string>  $input  The $argv variable.
+     * @param  array<string, string>  $shortOptions  Optional. An array with keys set to short options and their values set to the long option they're assigned to.
+     * @param  list<string>  $flagOptions  Optional. An array of options to be treated as flags. If a flag is not defined here, it will be treated as an option.
      */
-    public static function parse(string|array $input, $shortOptions = [], $flagOptions = []): Console
+    public static function parse(string|array $input, array $shortOptions = [], array $flagOptions = []): Console
     {
         if (empty($input)) {
             return new Console('', '');
@@ -35,13 +35,13 @@ class Console
 
         if (is_string($input)) {
             $input = trim($input);
-            $input = preg_split('/\s+(?=([^"]*"[^"]*")*[^"]*$)/', $input);
-            $input = array_map(function ($item) {
+            $parts = preg_split('/\s+(?=([^"]*"[^"]*")*[^"]*$)/', $input);
+            $input = array_map(function (string $item): string {
                 return trim($item, '"\'');
-            }, $input);
+            }, $parts === false ? [] : $parts);
         }
 
-        $command = array_shift($input);
+        $command = array_shift($input) ?? '';
         $arguments = [];
         $options = [];
         $flags = [];
@@ -61,12 +61,19 @@ class Console
                     continue;
                 }
             } else {
-                $arg_split = [];
-                preg_match('/^--?([A-Z\d\-_]+)=?(.+)?$/i', $arg, $arg_split);
-                $arg = $arg_split[1];
+                $argSplit = [];
 
-                if (count($arg_split) > 2) {
-                    $value = $arg_split[2];
+                if (preg_match('/^--?([A-Z\d\-_]+)=?(.+)?$/i', $arg, $argSplit) !== 1) {
+                    $arguments[] = $arg;
+                    $lastOption = null;
+
+                    continue;
+                }
+
+                $arg = $argSplit[1];
+
+                if (isset($argSplit[2])) {
+                    $value = $argSplit[2];
                 }
             }
 
@@ -74,8 +81,8 @@ class Console
                 $arg = $shortOptions[$arg];
             }
 
-            if (in_array($arg, $flagOptions)) {
-                if (! in_array($arg, $flags)) {
+            if (in_array($arg, $flagOptions, true)) {
+                if (! in_array($arg, $flags, true)) {
                     $flags[] = $arg;
                 }
 
@@ -109,12 +116,24 @@ class Console
 
     public function getOption(string $option): ?string
     {
-        return $this->options[$option] ?? null;
+        $value = $this->options[$option] ?? null;
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        foreach ($value as $optionValue) {
+            if ($optionValue !== null) {
+                return $optionValue;
+            }
+        }
+
+        return null;
     }
 
     public function hasFlag(string $flag): bool
     {
-        return in_array($flag, $this->flags);
+        return in_array($flag, $this->flags, true);
     }
 
     public function __toString(): string
@@ -134,15 +153,17 @@ class Console
 
     public function getOptionsString(): string
     {
-        return implode(' ', array_map(
-            function ($key, $value) {
-                return implode(' ', array_map(function ($v) use ($key) {
-                    return $v === null ? "--{$key}" : "--{$key}=".escapeshellarg($v);
-                }, $value === null ? [null] : (array) $value));
-            },
-            array_keys($this->options),
-            $this->options,
-        ));
+        $options = [];
+
+        foreach ($this->options as $key => $value) {
+            $values = is_array($value) ? $value : [$value];
+
+            foreach ($values as $optionValue) {
+                $options[] = $optionValue === null ? "--{$key}" : "--{$key}=".escapeshellarg($optionValue);
+            }
+        }
+
+        return implode(' ', $options);
     }
 
     public function getFlagsString(): string
@@ -150,7 +171,7 @@ class Console
         return implode(' ', $this->flags);
     }
 
-    public function exec(bool $verbose = false)
+    public function exec(bool $verbose = false): void
     {
         $descriptors = [
             0 => STDIN,

--- a/src/Console.php
+++ b/src/Console.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 use Cpx\Commands\Command;
@@ -183,7 +185,7 @@ class Console
             echo Command::BACKGROUND_CYAN."   Running command: '{$this}'   ".Command::COLOR_RESET;
         }
 
-        $process = proc_open($this, $descriptors, $pipes);
+        $process = proc_open((string) $this, $descriptors, $pipes);
 
         if (is_resource($process)) {
             proc_close($process);

--- a/src/Exceptions/ComposerInstallException.php
+++ b/src/Exceptions/ComposerInstallException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Exceptions;
 
 use Exception;

--- a/src/Exceptions/ConsoleException.php
+++ b/src/Exceptions/ConsoleException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx\Exceptions;
 
 use Exception;

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -29,7 +29,7 @@ class Metadata
 
             return new Metadata(
                 packages: Utils::arrayMapAssoc(
-                    fn ($key, $value) => [
+                    fn (string $key, array $value): array => [
                         $key => new PackageMetadata(
                             package: Package::parse($key),
                             lastUpdatedAt: $value['last_updated'] ?? null,
@@ -88,7 +88,7 @@ class Metadata
     {
         return [
             'packages' => Utils::arrayMapAssoc(
-                fn ($key, PackageMetadata $packageMetadata) => [
+                fn (string $key, PackageMetadata $packageMetadata): array => [
                     $packageMetadata->package->fullPackageString() => [
                         'last_updated' => $packageMetadata->lastUpdatedAt,
                         'last_run' => $packageMetadata->lastRunAt,

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 class Metadata

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -2,9 +2,6 @@
 
 namespace Cpx;
 
-use Cpx\Package;
-use Cpx\PackageMetadata;
-
 class Metadata
 {
     /** @param array<string,PackageMetadata> $packages */
@@ -35,15 +32,15 @@ class Metadata
             );
         }
 
-        return new Metadata();
+        return new Metadata;
     }
 
-    function updateLastCheckTime(Package $package, string $type = 'run'): Metadata
+    public function updateLastCheckTime(Package $package, string $type = 'run'): Metadata
     {
         $packageKey = $package->fullPackageString();
         $currentTime = date('Y-m-d H:i:s');
 
-        if (!isset($this->packages[$packageKey])) {
+        if (! isset($this->packages[$packageKey])) {
             $this->packages[$packageKey] = new PackageMetadata($package);
         }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -4,7 +4,10 @@ namespace Cpx;
 
 class Metadata
 {
-    /** @param array<string,PackageMetadata> $packages */
+    /**
+     * @param  array<string, PackageMetadata>  $packages
+     * @param  array<string, array{packages?: list<string>, last_updated?: int, last_run?: int}>  $execCache
+     */
     protected function __construct(
         public array $packages = [],
         public array $execCache = [],
@@ -15,7 +18,12 @@ class Metadata
         $metadataFile = cpx_path('.cpx_metadata.json');
 
         if (file_exists($metadataFile)) {
-            $json = json_decode(file_get_contents($metadataFile), true);
+            $contents = file_get_contents($metadataFile);
+            $json = $contents === false ? [] : json_decode($contents, true);
+
+            if (! is_array($json)) {
+                $json = [];
+            }
 
             return new Metadata(
                 packages: Utils::arrayMapAssoc(
@@ -26,9 +34,9 @@ class Metadata
                             lastRunAt: $value['last_run'] ?? null,
                         ),
                     ],
-                    $json['packages'] ?? [],
+                    is_array($json['packages'] ?? null) ? $json['packages'] : [],
                 ),
-                execCache: $json['execCache'] ?? [],
+                execCache: is_array($json['execCache'] ?? null) ? $json['execCache'] : [],
             );
         }
 
@@ -68,6 +76,12 @@ class Metadata
         return array_key_exists($package, $this->packages);
     }
 
+    /**
+     * @return array{
+     *     packages: array<string, array{last_updated: string|null, last_run: string|null}>,
+     *     execCache: array<string, array{packages?: list<string>, last_updated?: int, last_run?: int}>
+     * }
+     */
     public function toArray(): array
     {
         return [

--- a/src/Package.php
+++ b/src/Package.php
@@ -2,7 +2,6 @@
 
 namespace Cpx;
 
-use Cpx\Utils;
 use Cpx\Commands\Command;
 use InvalidArgumentException;
 
@@ -20,7 +19,7 @@ class Package
             throw new InvalidArgumentException('A package name must be provided.');
         }
 
-        if (!str_contains($str, '/')) {
+        if (! str_contains($str, '/')) {
             throw new InvalidArgumentException('A package name should be in the format "<vendor>/<package>');
         }
 
@@ -48,7 +47,7 @@ class Package
     public function fullPackageString(): string
     {
         return "{$this->vendor}/{$this->name}"
-            . ($this->version ? ':' . $this->version : '');
+            .($this->version ? ':'.$this->version : '');
     }
 
     public function delete(): void
@@ -79,24 +78,26 @@ class Package
 
             foreach ($possibleCommands as $possibleCommand) {
                 if (in_array($possibleCommand, $binScripts)) {
-                    if ($console->arguments[0] ?? null === $possibleCommand) {
+                    if ($console->arguments[0] ?? $possibleCommand === null) {
                         unset($console->arguments[0]);
                         $console->arguments = array_values($console->arguments);
                     }
                     $command = $possibleCommand;
+
                     break;
                 } elseif (array_key_exists($possibleCommand, $binScripts)) {
-                    if ($console->arguments[0] ?? null === $possibleCommand) {
+                    if ($console->arguments[0] ?? $possibleCommand === null) {
                         unset($console->arguments[0]);
                         $console->arguments = array_values($console->arguments);
                     }
                     $command = $binScripts[$possibleCommand];
+
                     break;
                 }
             }
 
-            if (!isset($command)) {
-                echo Command::BACKGROUND_RED . "   More than 1 bin command found for {$this}: " . join(', ', array_keys($binScripts)) . '   ' . Command::COLOR_RESET . PHP_EOL;
+            if (! isset($command)) {
+                echo Command::BACKGROUND_RED."   More than 1 bin command found for {$this}: ".implode(', ', array_keys($binScripts)).'   '.Command::COLOR_RESET.PHP_EOL;
                 exit();
             }
         } else {
@@ -134,11 +135,11 @@ class Package
     {
         $installDir = cpx_path($this->folder());
 
-        if (!is_dir($installDir)) {
+        if (! is_dir($installDir)) {
             mkdir($installDir, 0755, true);
         }
 
-        if (!is_dir("$installDir/vendor")) {
+        if (! is_dir("$installDir/vendor")) {
             printColor("Installing {$this}...");
             file_put_contents("{$installDir}/composer.json", json_encode([
                 'name' => "cpx-{$this->vendor}/cpx-{$this->name}",
@@ -159,7 +160,7 @@ class Package
         } elseif ($updateCheck && $this->shouldCheckForUpdates($this)) {
             printColor("Checking for updates for {$this}...");
             $previousVersion = Composer::getCurrentVersion($installDir);
-            Composer::runCommand("update", $installDir);
+            Composer::runCommand('update', $installDir);
             $newVersion = Composer::getCurrentVersion($installDir);
 
             if ($previousVersion !== $newVersion) {
@@ -176,12 +177,12 @@ class Package
         return $installDir;
     }
 
-    function shouldCheckForUpdates(): bool
+    public function shouldCheckForUpdates(): bool
     {
         $metadata = Metadata::open();
         $packageKey = $this->fullPackageString();
 
-        if (!$metadata->hasPackage($this)) {
+        if (! $metadata->hasPackage($this)) {
             return true;
         }
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -68,7 +68,7 @@ class Package
             throw new RuntimeException("No bin command found in {$this}.");
         }
 
-        $binScripts = Utils::arrayMapAssoc(fn ($key, $value) => [basename($value) => $value], $binScripts);
+        $binScripts = Utils::arrayMapAssoc(fn (int $_, string $value): array => [basename($value) => $value], $binScripts);
 
         if (count($binScripts) > 1) {
             $possibleCommands = array_values(array_unique(array_filter([

--- a/src/Package.php
+++ b/src/Package.php
@@ -77,18 +77,16 @@ class Package
             ])));
 
             foreach ($possibleCommands as $possibleCommand) {
-                if (in_array($possibleCommand, $binScripts)) {
-                    if ($console->arguments[0] ?? $possibleCommand === null) {
-                        unset($console->arguments[0]);
-                        $console->arguments = array_values($console->arguments);
+                if (in_array($possibleCommand, $binScripts, true)) {
+                    if (($console->arguments[0] ?? null) === $possibleCommand) {
+                        $console->arguments = array_slice($console->arguments, 1);
                     }
                     $command = $possibleCommand;
 
                     break;
                 } elseif (array_key_exists($possibleCommand, $binScripts)) {
-                    if ($console->arguments[0] ?? $possibleCommand === null) {
-                        unset($console->arguments[0]);
-                        $console->arguments = array_values($console->arguments);
+                    if (($console->arguments[0] ?? null) === $possibleCommand) {
+                        $console->arguments = array_slice($console->arguments, 1);
                     }
                     $command = $binScripts[$possibleCommand];
 
@@ -157,7 +155,7 @@ class Package
             }
 
             Metadata::open()->updateLastCheckTime($this, 'updated')->save();
-        } elseif ($updateCheck && $this->shouldCheckForUpdates($this)) {
+        } elseif ($updateCheck && $this->shouldCheckForUpdates()) {
             printColor("Checking for updates for {$this}...");
             $previousVersion = Composer::getCurrentVersion($installDir);
             Composer::runCommand('update', $installDir);
@@ -186,7 +184,17 @@ class Package
             return true;
         }
 
-        $lastCheck = strtotime($metadata->packages[$packageKey]->lastUpdatedAt);
+        $lastUpdatedAt = $metadata->packages[$packageKey]->lastUpdatedAt;
+
+        if ($lastUpdatedAt === null) {
+            return true;
+        }
+
+        $lastCheck = strtotime($lastUpdatedAt);
+
+        if ($lastCheck === false) {
+            return true;
+        }
 
         return (time() - $lastCheck) > 3600; // 1 hour
     }

--- a/src/Package.php
+++ b/src/Package.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cpx;
 
-use Cpx\Commands\Command;
 use InvalidArgumentException;
 use RuntimeException;
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 use Cpx\Commands\Command;
 use InvalidArgumentException;
+use RuntimeException;
 
 class Package
 {
@@ -52,8 +55,7 @@ class Package
 
     public function delete(): void
     {
-        $packageDirectory = cpx_path("{$this->folder()}");
-        exec("rm -rf {$packageDirectory}");
+        Utils::deleteDirectory(cpx_path("{$this->folder()}"));
     }
 
     public function runCommand(Console $console, bool $autoUpdate = true): void
@@ -63,8 +65,7 @@ class Package
         $binScripts = Composer::detectBinFromComposer("{$installDir}/vendor/{$this->vendor}/{$this->name}");
 
         if (empty($binScripts)) {
-            printColor("Error: No bin command found in {$this}.", "\033[1;31m");
-            exit(1);
+            throw new RuntimeException("No bin command found in {$this}.");
         }
 
         $binScripts = Utils::arrayMapAssoc(fn ($key, $value) => [basename($value) => $value], $binScripts);
@@ -95,8 +96,7 @@ class Package
             }
 
             if (! isset($command)) {
-                echo Command::BACKGROUND_RED."   More than 1 bin command found for {$this}: ".implode(', ', array_keys($binScripts)).'   '.Command::COLOR_RESET.PHP_EOL;
-                exit();
+                throw new RuntimeException("More than 1 bin command found for {$this}: ".implode(', ', array_keys($binScripts)).'.');
             }
         } else {
             $command = $binScripts[array_key_first($binScripts)];

--- a/src/PackageAliases.php
+++ b/src/PackageAliases.php
@@ -4,6 +4,7 @@ namespace Cpx;
 
 class PackageAliases
 {
+    /** @var array<string, array{name: string, description: string, command: string, package: string}> */
     public static array $packages = [
         'psalm' => [
             'name' => 'Psalm',

--- a/src/PackageAliases.php
+++ b/src/PackageAliases.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 class PackageAliases

--- a/src/PackageMetadata.php
+++ b/src/PackageMetadata.php
@@ -2,8 +2,6 @@
 
 namespace Cpx;
 
-use Cpx\Package;
-
 class PackageMetadata
 {
     public function __construct(

--- a/src/PackageMetadata.php
+++ b/src/PackageMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
 
 class PackageMetadata

--- a/src/PhpExecutionHelper.php
+++ b/src/PhpExecutionHelper.php
@@ -25,7 +25,13 @@ class PhpExecutionHelper
         $autoloadFile = $autoloadRootDirectory.$autoloadFileSuffix;
 
         while (! file_exists($autoloadFile)) {
-            $autoloadRootDirectory = realpath(dirname($autoloadRootDirectory));
+            $parentDirectory = realpath(dirname($autoloadRootDirectory));
+
+            if ($parentDirectory === false) {
+                break;
+            }
+
+            $autoloadRootDirectory = $parentDirectory;
             $autoloadFile = $autoloadRootDirectory.$autoloadFileSuffix;
 
             if ($autoloadRootDirectory === '/') {

--- a/src/PhpExecutionHelper.php
+++ b/src/PhpExecutionHelper.php
@@ -14,20 +14,19 @@ class PhpExecutionHelper
         bool $shouldLoadLaravelBootstrap = true,
         bool $shouldAliasClasses = true,
         bool $shouldBeVerbose = false,
-    ): void
-    {
-        if (!$shouldFindAutoloader) {
+    ): void {
+        if (! $shouldFindAutoloader) {
             return;
         }
 
         $autoloadRootDirectory = $path;
 
         $autoloadFileSuffix = '/vendor/autoload.php';
-        $autoloadFile = $autoloadRootDirectory . $autoloadFileSuffix;
+        $autoloadFile = $autoloadRootDirectory.$autoloadFileSuffix;
 
-        while (!file_exists($autoloadFile)) {
+        while (! file_exists($autoloadFile)) {
             $autoloadRootDirectory = realpath(dirname($autoloadRootDirectory));
-            $autoloadFile = $autoloadRootDirectory . $autoloadFileSuffix;
+            $autoloadFile = $autoloadRootDirectory.$autoloadFileSuffix;
 
             if ($autoloadRootDirectory === '/') {
                 break;
@@ -36,26 +35,26 @@ class PhpExecutionHelper
 
         if (file_exists($autoloadFile)) {
             if ($shouldBeVerbose) {
-                echo "Found autoload file at '{$autoloadFile}'" . PHP_EOL;
+                echo "Found autoload file at '{$autoloadFile}'".PHP_EOL;
             }
 
             require_once $autoloadFile;
 
-            if ($shouldLoadLaravelBootstrap && file_exists($autoloadRootDirectory . '/bootstrap/app.php')) {
+            if ($shouldLoadLaravelBootstrap && file_exists($autoloadRootDirectory.'/bootstrap/app.php')) {
                 if ($shouldBeVerbose) {
-                    echo "Found Laravel bootstrap file at '{$autoloadRootDirectory}/bootstrap/app.php'" . PHP_EOL;
+                    echo "Found Laravel bootstrap file at '{$autoloadRootDirectory}/bootstrap/app.php'".PHP_EOL;
                 }
 
-                if (!defined('LARAVEL_START')) {
+                if (! defined('LARAVEL_START')) {
                     define('LARAVEL_START', microtime(true));
                 }
 
-                require_once $autoloadRootDirectory . '/bootstrap/app.php';
+                require_once $autoloadRootDirectory.'/bootstrap/app.php';
             }
 
             if ($shouldAliasClasses) {
                 if ($shouldBeVerbose) {
-                    echo 'Aliasing classes' . PHP_EOL;
+                    echo 'Aliasing classes'.PHP_EOL;
                 }
 
                 static::getClassAliasAutoloader($shouldBeVerbose)->addAliases($autoloadRootDirectory);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -4,6 +4,16 @@ namespace Cpx;
 
 class Utils
 {
+    /**
+     * @template TKey of array-key
+     * @template TValue
+     * @template TReturnKey of array-key
+     * @template TReturnValue
+     *
+     * @param  callable(TKey, TValue): array<TReturnKey, TReturnValue>  $f
+     * @param  array<TKey, TValue>  $a
+     * @return array<TReturnKey, TReturnValue>
+     */
     public static function arrayMapAssoc(callable $f, array $a): array
     {
         return array_merge(...array_map($f, array_keys($a), $a));

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,6 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cpx;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 class Utils
 {
@@ -17,5 +24,28 @@ class Utils
     public static function arrayMapAssoc(callable $f, array $a): array
     {
         return array_merge(...array_map($f, array_keys($a), $a));
+    }
+
+    public static function deleteDirectory(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            return;
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            /** @var SplFileInfo $file */
+            if ($file->isDir() && ! $file->isLink()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($directory);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -5,11 +5,12 @@ use Cpx\Exceptions\ComposerInstallException;
 use Cpx\Metadata;
 use Cpx\PhpExecutionHelper;
 
-if (!function_exists('composer_require')) {
+if (! function_exists('composer_require')) {
     /**
      * Dynamically requires Composer packages in a sandboxed environment.
      *
-     * @param string ...$packages List of packages to require in the format vendor/package[:version].
+     * @param  string  ...$packages  List of packages to require in the format vendor/package[:version].
+     *
      * @throws Exception If the Composer require command fails.
      */
     function composer_require(string ...$packages): void
@@ -21,14 +22,14 @@ if (!function_exists('composer_require')) {
 
         $metadata = Metadata::open();
 
-        if (!is_dir($sandboxDir)) {
+        if (! is_dir($sandboxDir)) {
             mkdir($sandboxDir, 0755, true);
 
-            file_put_contents($sandboxDir . '/composer.json', json_encode([
-                'require' => new stdClass(),
+            file_put_contents($sandboxDir.'/composer.json', json_encode([
+                'require' => new stdClass,
                 'config' => [
-                    'vendor-dir' => './vendor'
-                ]
+                    'vendor-dir' => './vendor',
+                ],
             ], JSON_PRETTY_PRINT));
 
             // Run `composer require` for each package
@@ -44,7 +45,7 @@ if (!function_exists('composer_require')) {
             if (isset($metadata->execCache[$hash]['last_updated']) && time() - $metadata->execCache[$hash]['last_updated'] >= 3600) {
                 // Composer update was not run within the last hour
                 try {
-                    Composer::runCommand("update --no-interaction --quiet", $sandboxDir);
+                    Composer::runCommand('update --no-interaction --quiet', $sandboxDir);
                     $metadata->execCache[$hash]['last_updated'] = time();
                 } catch (Exception $e) {
                     // Update failed, let's just use the existing folder.
@@ -58,7 +59,7 @@ if (!function_exists('composer_require')) {
 
         $autoloadFile = "{$sandboxDir}/vendor/autoload.php";
 
-        if (!file_exists($autoloadFile)) {
+        if (! file_exists($autoloadFile)) {
             throw new Exception("Autoload file not found in {$sandboxDir}/vendor/. Composer installation may have failed.");
         }
 
@@ -70,11 +71,11 @@ if (!function_exists('composer_require')) {
     }
 }
 
-if (!function_exists('cpx_path')) {
+if (! function_exists('cpx_path')) {
     function cpx_path(string $path = ''): string
     {
         $home = $_SERVER['HOME'] ?? __DIR__;
 
-        return "{$home}/.cpx/" . trim($path, '/');
+        return "{$home}/.cpx/".trim($path, '/');
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -79,3 +79,10 @@ if (! function_exists('cpx_path')) {
         return "{$home}/.cpx/".trim($path, '/');
     }
 }
+
+if (! function_exists('printColor')) {
+    function printColor(string $message, string $color = "\033[1;32m"): void
+    {
+        echo $color.$message."\033[0m".PHP_EOL;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Cpx\Composer;
 use Cpx\Exceptions\ComposerInstallException;
 use Cpx\Metadata;
@@ -17,7 +19,7 @@ if (! function_exists('composer_require')) {
     {
         sort($packages);
 
-        $hash = md5(implode(' ', $packages));
+        $hash = hash('sha256', implode(' ', $packages));
         $sandboxDir = cpx_path(".exec_cache/{$hash}");
 
         $metadata = Metadata::open();

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+arch()->preset()->php();
+
+arch('it will not use dd(), ddd(), env(), or exit()')
+    ->expect(['dd', 'ddd', 'env', 'exit'])
+    ->each->not->toBeUsed();
+
+arch('it will not use risky security functions')
+    ->expect([
+        'md5',
+        'sha1',
+        'uniqid',
+        'rand',
+        'mt_rand',
+        'tempnam',
+        'str_shuffle',
+        'shuffle',
+        'array_rand',
+        'exec',
+        'shell_exec',
+        'system',
+        'passthru',
+        'create_function',
+        'unserialize',
+        'extract',
+        'mb_parse_str',
+        'dl',
+        'assert',
+    ])
+    ->each->not->toBeUsed();
+
+arch('the package source declares strict types')
+    ->expect('Cpx')
+    ->toUseStrictTypes();

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "pest()" function to bind different classes or traits.
+|
+*/
+
+pest()->extend(TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,46 +2,4 @@
 
 use Tests\TestCase;
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind different classes or traits.
-|
-*/
-
 pest()->extend(TestCase::class)->in('Feature');
-
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-function something()
-{
-    // ..
-}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
This prepares the package for ongoing maintenance on the 2.x branch by adding the quality checks needed to keep changes safe and consistent.

It raises the package requirement to PHP 8.3, adds Pint, PHPStan, Pest architecture and type coverage checks, and wires the Composer scripts into CI across PHP 8.3, 8.4, and 8.5 with SHA-pinned GitHub Actions. It also adds Dependabot for grouped GitHub Actions updates.