### PR TITLE
Add package runner contract tests

### DIFF
--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -66,6 +66,11 @@ class Metadata
     public function save(): void
     {
         $metadataFile = cpx_path('.cpx_metadata.json');
+
+        if (! is_dir(dirname($metadataFile))) {
+            mkdir(dirname($metadataFile), 0755, true);
+        }
+
         file_put_contents($metadataFile, json_encode($this->toArray(), JSON_PRETTY_PRINT));
     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -66,9 +66,10 @@ class Metadata
     public function save(): void
     {
         $metadataFile = cpx_path('.cpx_metadata.json');
+        $dir = dirname($metadataFile);
 
-        if (! is_dir(dirname($metadataFile))) {
-            mkdir(dirname($metadataFile), 0755, true);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
         }
 
         file_put_contents($metadataFile, json_encode($this->toArray(), JSON_PRETTY_PRINT));

--- a/src/Package.php
+++ b/src/Package.php
@@ -22,7 +22,7 @@ class Package
             throw new InvalidArgumentException('A package name must be provided.');
         }
 
-        if (preg_match('/\A(?<vendor>[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)\/(?<name>[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)(?::(?<version>[a-zA-Z0-9_.@~^*<>!=|,-]+))?\z/', $str, $matches) !== 1) {
+        if (preg_match('/\A(?<vendor>[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)\/(?<name>[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)(?::(?<version>[a-zA-Z0-9_.@~^*<>!=|,\/-]+))?\z/', $str, $matches) !== 1) {
             throw new InvalidArgumentException('A package name should be in the format "<vendor>/<package>[:version]".');
         }
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -22,19 +22,15 @@ class Package
             throw new InvalidArgumentException('A package name must be provided.');
         }
 
-        if (! str_contains($str, '/')) {
-            throw new InvalidArgumentException('A package name should be in the format "<vendor>/<package>');
+        if (preg_match('/\A(?<vendor>[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)\/(?<name>[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?)(?::(?<version>[a-zA-Z0-9_.@~^*<>!=|,-]+))?\z/', $str, $matches) !== 1) {
+            throw new InvalidArgumentException('A package name should be in the format "<vendor>/<package>[:version]".');
         }
 
-        $parts = explode(':', str_replace('@', ':', $str));
-        [$vendor, $name] = explode('/', $parts[0]);
-        $version = $parts[1] ?? null;
-
-        if ($version === '') {
-            $version = null;
-        }
-
-        return new Package($vendor, $name, $version);
+        return new Package(
+            vendor: $matches['vendor'],
+            name: $matches['name'],
+            version: $matches['version'] ?? null,
+        );
     }
 
     public function folder(): string

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -23,7 +23,7 @@ class Utils
      */
     public static function arrayMapAssoc(callable $f, array $a): array
     {
-        return array_merge(...array_map($f, array_keys($a), $a));
+        return $a === [] ? [] : array_merge(...array_map($f, array_keys($a), $a));
     }
 
     public static function deleteDirectory(string $directory): void

--- a/src/functions.php
+++ b/src/functions.php
@@ -76,7 +76,7 @@ if (! function_exists('composer_require')) {
 if (! function_exists('cpx_path')) {
     function cpx_path(string $path = ''): string
     {
-        $home = $_SERVER['HOME'] ?? __DIR__;
+        $home = $_SERVER['COMPOSER_HOME'] ?? getenv('COMPOSER_HOME') ?: ($_SERVER['HOME'] ?? __DIR__);
 
         return "{$home}/.cpx/".trim($path, '/');
     }

--- a/tests/Feature/BinaryResolutionTest.php
+++ b/tests/Feature/BinaryResolutionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+test('a package with one binary runs without requiring a binary name')->todo(
+    'Enable when package binaries are executed through the safe process runner.',
+);
+
+test('a package with multiple binaries uses the first forwarded argument as the binary name')->todo(
+    'Enable when multiple-binary packages are resolved through validated targets.',
+);
+
+test('ambiguous multiple-binary packages list the available binaries')->todo(
+    'Enable when multiple-binary packages return actionable ambiguity errors.',
+);

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Cpx\Commands\CleanCommand;
+use Cpx\Console;
+
+test('it removes all tracked package and exec cache directories', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    $execDirectory = cpx_path('.exec_cache/sandbox');
+
+    mkdir($packageDirectory, 0755, true);
+    mkdir($execDirectory, 0755, true);
+
+    if (! is_dir(dirname(cpx_path('.cpx_metadata.json')))) {
+        mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    }
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => '2024-01-01 00:00:00',
+                'last_run' => '2024-01-01 00:00:00',
+            ],
+        ],
+        'execCache' => [
+            'sandbox' => [
+                'packages' => ['laravel/pint'],
+                'last_updated' => 1,
+                'last_run' => 1,
+            ],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    ob_start();
+    (new CleanCommand(Console::parse(['clean', '--all'])))->__invoke();
+    ob_end_clean();
+
+    expect(is_dir($packageDirectory))->toBeFalse()
+        ->and(is_dir($execDirectory))->toBeFalse()
+        ->and(json_decode((string) file_get_contents(cpx_path('.cpx_metadata.json')), true))->toBe([
+            'packages' => [],
+            'execCache' => [],
+        ]);
+});
+
+test('it preserves fresh tracked package cache directories', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+
+    mkdir($packageDirectory, 0755, true);
+
+    if (! is_dir(dirname(cpx_path('.cpx_metadata.json')))) {
+        mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    }
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => date('Y-m-d H:i:s'),
+                'last_run' => date('Y-m-d H:i:s'),
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    ob_start();
+    (new CleanCommand(Console::parse(['clean'])))->__invoke();
+    ob_end_clean();
+
+    expect(is_dir($packageDirectory))->toBeTrue();
+});
+
+test('orphaned package directories are detected and cleaned')->todo(
+    'Enable when cleanup scans for cache directories missing from metadata.',
+);
+
+test('cleanup refuses to delete paths outside the cpx cache root')->todo(
+    'Enable when cleanup validates every deletion stays inside the cpx cache root.',
+);

--- a/tests/Feature/CliArgumentForwardingTest.php
+++ b/tests/Feature/CliArgumentForwardingTest.php
@@ -1,0 +1,17 @@
+<?php
+
+test('package arguments are forwarded exactly as argv tokens')->todo(
+    'Enable when the process runner forwards argv tokens without shell reconstruction.',
+);
+
+test('short flags, long flags, repeated options, and option values are preserved')->todo(
+    'Enable when forwarded package options are preserved as original argv tokens.',
+);
+
+test('a target binary exit code becomes the cpx exit code')->todo(
+    'Enable when child process exit codes are propagated through the cpx executable.',
+);
+
+test('a missing target binary returns a non-zero status with an actionable error')->todo(
+    'Enable when missing binaries produce explicit non-zero failures.',
+);

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Feature/LocalBinaryPreferenceTest.php
+++ b/tests/Feature/LocalBinaryPreferenceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+test('it runs a local vendor bin before installing an isolated package')->todo(
+    'Enable when local project binaries are resolved before isolated package installs.',
+);
+
+test('it discovers a custom composer bin-dir before remote package resolution')->todo(
+    'Enable when local Composer bin-dir discovery is implemented.',
+);
+
+test('local binary execution preserves forwarded arguments and exit codes')->todo(
+    'Enable when local binary execution uses argv tokens and propagates exit codes.',
+);
+
+test('missing local binaries fall back to alias or package resolution')->todo(
+    'Enable when local binary lookup has a documented remote fallback path.',
+);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,35 +13,4 @@ use Tests\TestCase;
 |
 */
 
-pest()->extend(TestCase::class)->in('Feature');
-
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-function something()
-{
-    // ..
-}
+pest()->extend(TestCase::class)->in('Feature', 'Unit');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,96 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /** @var array<string, string|false> */
+    private array $environment = [];
+
+    /** @var array<string, string|null> */
+    private array $server = [];
+
+    /** @var list<string> */
+    private array $temporaryDirectories = [];
+
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->temporaryDirectories) as $directory) {
+            $this->deleteDirectory($directory);
+        }
+
+        foreach ($this->environment as $name => $value) {
+            $value === false ? putenv($name) : putenv("{$name}={$value}");
+        }
+
+        foreach ($this->server as $name => $value) {
+            if ($value === null) {
+                unset($_SERVER[$name]);
+
+                continue;
+            }
+
+            $_SERVER[$name] = $value;
+        }
+
+        parent::tearDown();
+    }
+
+    protected function temporaryDirectory(string $prefix = 'cpx-test'): string
+    {
+        $directory = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(8));
+
+        mkdir($directory, 0755, true);
+
+        $this->temporaryDirectories[] = $directory;
+
+        return $directory;
+    }
+
+    protected function useIsolatedComposerHome(): string
+    {
+        $home = $this->temporaryDirectory('cpx-home');
+        $composerHome = "{$home}/composer";
+
+        mkdir($composerHome, 0755, true);
+
+        $this->setEnvironmentVariable('HOME', $home);
+        $this->setEnvironmentVariable('COMPOSER_HOME', $composerHome);
+
+        return $composerHome;
+    }
+
+    protected function setEnvironmentVariable(string $name, string $value): void
+    {
+        if (! array_key_exists($name, $this->environment)) {
+            $this->environment[$name] = getenv($name);
+        }
+
+        if (! array_key_exists($name, $this->server)) {
+            $this->server[$name] = $_SERVER[$name] ?? null;
+        }
+
+        putenv("{$name}={$value}");
+        $_SERVER[$name] = $value;
+    }
+
+    private function deleteDirectory(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            return;
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($directory);
+    }
 }

--- a/tests/Unit/ConsoleTest.php
+++ b/tests/Unit/ConsoleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Cpx\Console;
+
+test('it parses the command and positional arguments from argv tokens', function () {
+    $console = Console::parse(['laravel/pint', '--test', 'app', 'two words'], flagOptions: ['test']);
+
+    expect($console->command)->toBe('laravel/pint')
+        ->and($console->arguments)->toBe(['app', 'two words'])
+        ->and($console->hasFlag('test'))->toBeTrue();
+});
+
+test('it keeps repeated option values in order', function () {
+    $console = Console::parse(['tool', '--filter=one', '--filter=two']);
+
+    expect($console->options['filter'])->toBe(['one', 'two'])
+        ->and($console->getOption('filter'))->toBe('one');
+});
+
+test('it maps configured short options and flags', function () {
+    $console = Console::parse(
+        ['tool', '-v', '-c', 'phpstan.neon'],
+        shortOptions: ['c' => 'configuration', 'v' => 'verbose'],
+        flagOptions: ['verbose'],
+    );
+
+    expect($console->hasFlag('verbose'))->toBeTrue()
+        ->and($console->getOption('configuration'))->toBe('phpstan.neon');
+});
+
+test('the double-dash separator preserves all following target arguments')->todo(
+    'Enable when the process runner forwards argv tokens without shell reconstruction.',
+);
+
+test('child process exit codes are returned through the command runner')->todo(
+    'Enable when child process exit codes are propagated through the command runner.',
+);

--- a/tests/Unit/CpxPathTest.php
+++ b/tests/Unit/CpxPathTest.php
@@ -1,0 +1,7 @@
+<?php
+
+test('it stores cpx state under composer home when available', function () {
+    $composerHome = $this->useIsolatedComposerHome();
+
+    expect(cpx_path('metadata.json'))->toBe("{$composerHome}/.cpx/metadata.json");
+});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Cpx\Metadata;
+use Cpx\Package;
+
+test('it opens an empty metadata state when no metadata file exists', function () {
+    $this->useIsolatedComposerHome();
+
+    $metadata = Metadata::open();
+
+    expect($metadata->packages)->toBe([])
+        ->and($metadata->execCache)->toBe([]);
+});
+
+test('it saves readable metadata json and round trips package timestamps', function () {
+    $this->useIsolatedComposerHome();
+
+    Metadata::open()
+        ->updateLastCheckTime(Package::parse('laravel/pint'), 'updated')
+        ->updateLastCheckTime(Package::parse('laravel/pint'))
+        ->save();
+
+    $metadataFile = cpx_path('.cpx_metadata.json');
+    $contents = file_get_contents($metadataFile);
+    $metadata = Metadata::open();
+
+    expect($contents)->not->toBeFalse()
+        ->and(json_decode((string) $contents, true))->toHaveKey('packages')
+        ->and($metadata->hasPackage('laravel/pint'))->toBeTrue()
+        ->and($metadata->packages['laravel/pint']->lastUpdatedAt)->not->toBeNull()
+        ->and($metadata->packages['laravel/pint']->lastRunAt)->not->toBeNull();
+});
+
+test('it handles invalid metadata json as an empty state', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), '{invalid');
+
+    $metadata = Metadata::open();
+
+    expect($metadata->packages)->toBe([])
+        ->and($metadata->execCache)->toBe([]);
+});

--- a/tests/Unit/PackageAliasesTest.php
+++ b/tests/Unit/PackageAliasesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Cpx\PackageAliases;
+
+test('it includes default aliases for common Laravel ecosystem tools', function (string $alias, string $package, string $command) {
+    expect(array_key_exists($alias, PackageAliases::$packages))->toBeTrue()
+        ->and(PackageAliases::$packages[$alias]['package'])->toBe($package)
+        ->and(PackageAliases::$packages[$alias]['command'])->toBe($command);
+})->with([
+    ['pint', 'laravel/pint', 'pint'],
+    ['phpstan', 'phpstan/phpstan', 'phpstan'],
+    ['rector', 'rector/rector', 'rector'],
+]);
+
+test('each default alias has the required package runner fields', function () {
+    foreach (PackageAliases::$packages as $alias => $package) {
+        expect(array_keys($package))->toContain('name', 'description', 'command', 'package')
+            ->and($package['name'])->not->toBe('')
+            ->and($package['description'])->not->toBe('')
+            ->and($package['command'])->not->toBe('')
+            ->and($package['package'])->toContain('/');
+    }
+});
+
+test('alias dispatch uses the alias command field when selecting among multiple binaries')->todo(
+    'Enable when binary selection uses validated alias metadata.',
+);
+
+test('aliases can be added or overridden through user-managed config')->todo(
+    'Enable when aliases move from hardcoded defaults to user-managed config.',
+);

--- a/tests/Unit/PackageTest.php
+++ b/tests/Unit/PackageTest.php
@@ -21,6 +21,7 @@ test('it preserves version constraints and stability flags', function (string $t
     ['laravel/pint:^1.2', '^1.2'],
     ['laravel/pint:1.0.0', '1.0.0'],
     ['laravel/pint:dev-main', 'dev-main'],
+    ['laravel/pint:feat/new-cool-thing', 'feat/new-cool-thing'],
     ['laravel/pint:^1@dev', '^1@dev'],
 ]);
 

--- a/tests/Unit/PackageTest.php
+++ b/tests/Unit/PackageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Cpx\Package;
+
+test('it parses a package target without a version constraint', function () {
+    $package = Package::parse('laravel/pint');
+
+    expect($package->vendor)->toBe('laravel')
+        ->and($package->name)->toBe('pint')
+        ->and($package->version)->toBeNull()
+        ->and($package->versionName())->toBe('latest')
+        ->and($package->fullPackageString())->toBe('laravel/pint');
+});
+
+test('it preserves version constraints and stability flags', function (string $target, string $version) {
+    $package = Package::parse($target);
+
+    expect($package->version)->toBe($version)
+        ->and($package->fullPackageString())->toBe($target);
+})->with([
+    ['laravel/pint:^1.2', '^1.2'],
+    ['laravel/pint:1.0.0', '1.0.0'],
+    ['laravel/pint:dev-main', 'dev-main'],
+    ['laravel/pint:^1@dev', '^1@dev'],
+]);
+
+test('it accepts composer package names with supported punctuation', function (string $target) {
+    $package = Package::parse($target);
+
+    expect($package->fullPackageString())->toBe($target);
+})->with([
+    'vendor-name/package_name',
+    'vendor.name/package-name',
+    'vendor123/package.456',
+]);
+
+test('it rejects invalid package targets', function (string $target) {
+    Package::parse($target);
+})->with([
+    '',
+    'laravel',
+    '/pint',
+    'laravel/',
+    'Laravel/pint',
+    'laravel/Pint',
+    'laravel/pint extra',
+    '../laravel/pint',
+    'laravel/../pint',
+    'laravel/pint;rm -rf',
+    'laravel/pint|cat',
+    'laravel/pint/name',
+    'laravel/pint:',
+])->throws(InvalidArgumentException::class);
+
+test('package cache keys are derived from validated identifiers or stable safe hashes')->todo(
+    'Enable when cache keys are redesigned to avoid raw constraint punctuation.',
+);

--- a/tests/Unit/TestSupportTest.php
+++ b/tests/Unit/TestSupportTest.php
@@ -1,0 +1,9 @@
+<?php
+
+test('it isolates home and composer home during tests', function () {
+    $composerHome = $this->useIsolatedComposerHome();
+
+    expect(getenv('COMPOSER_HOME'))->toBe($composerHome)
+        ->and($_SERVER['COMPOSER_HOME'])->toBe($composerHome)
+        ->and(is_dir($composerHome))->toBeTrue();
+});


### PR DESCRIPTION
This adds the first set of behavior-focused tests around the package runner so the next v2 changes have a clear safety net. The suite now covers package parsing, aliases, console parsing, cache paths, metadata, cleanup behavior, and future contracts for binary resolution, argument forwarding, and local binary preference.

It also tightens package target parsing, moves CPX state under Composer home when available, and makes metadata writes safe for a fresh cache directory.