### PR TITLE
Add coverage for positional arguments with multiple binaries

### DIFF
--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -38,9 +38,7 @@ class ExecCommand extends Command
         } finally {
             $contents = ob_get_clean();
 
-            if ($contents !== false) {
-                $output->write($contents);
-            }
+            $output->write($contents);
         }
     }
 

--- a/tests/Feature/BinaryResolutionTest.php
+++ b/tests/Feature/BinaryResolutionTest.php
@@ -29,6 +29,21 @@ test('a package with multiple binaries uses the first forwarded argument as the 
         ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['--flag']);
 });
 
+test('a package with multiple binaries keeps a positional argument when a binary matches the package name', function () {
+    $this->useIsolatedComposerHome();
+    $logFile = $this->temporaryDirectory('cpx-log').'/argv.json';
+
+    prepareCachedPackage('vendor/package', ['package', 'other'], [
+        'package' => "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', json_encode(array_slice(\$argv, 1), JSON_THROW_ON_ERROR)); exit(0);\n",
+        'other' => "#!/usr/bin/env php\n<?php exit(99);\n",
+    ]);
+
+    [$status] = runCpxCommand(['vendor/package', 'tests/Sub']);
+
+    expect($status)->toBe(0)
+        ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['tests/Sub']);
+});
+
 test('ambiguous multiple-binary packages list the available binaries', function () {
     $this->useIsolatedComposerHome();
 


### PR DESCRIPTION
This is already fixed on 2.x, but I couldn't find any tests covering it so I added one here.

The bug is still present on v1 (the currently released version): there `?? null === $possibleCommand` gets parsed wrong because of operator precedence, so the first positional argument is dropped. I opened a separate fix for that against the v1 branch: https://github.com/laravel/cpx/pull/21

Related to #15
