### PR TITLE
Fix dropped positional argument for packages with multiple bins

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -79,14 +79,14 @@ class Package
 
             foreach ($possibleCommands as $possibleCommand) {
                 if (in_array($possibleCommand, $binScripts)) {
-                    if ($console->arguments[0] ?? null === $possibleCommand) {
+                    if (($console->arguments[0] ?? null) === $possibleCommand) {
                         unset($console->arguments[0]);
                         $console->arguments = array_values($console->arguments);
                     }
                     $command = $possibleCommand;
                     break;
                 } elseif (array_key_exists($possibleCommand, $binScripts)) {
-                    if ($console->arguments[0] ?? null === $possibleCommand) {
+                    if (($console->arguments[0] ?? null) === $possibleCommand) {
                         unset($console->arguments[0]);
                         $console->arguments = array_values($console->arguments);
                     }


### PR DESCRIPTION
For packages with more than one bin, the first positional argument was always dropped because `$console->arguments[0] ?? null === $possibleCommand` is parsed as `$console->arguments[0] ?? (null === $possibleCommand)` (`===` binds tighter than `??`), so the guard unset the argument whenever one was present. Wrapping the `?? null` in parentheses fixes it. For example, `cpx brianium/paratest tests/Sub` now runs just `tests/Sub` instead of the whole suite.

Fixes #15
