### PR TITLE
Make the cpx cache layer atomic and concurrent-safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,13 @@
     },
     "require": {
         "php": "^8.3",
+        "laravel/prompts": "^0.3.21",
         "symfony/console": "^7.4|^8.0"
     },
     "require-dev": {
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.29",
+        "mockery/mockery": "^1.6",
         "pestphp/pest": "^4.7",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan": "^2.2"

--- a/src/Cache/ExecSandboxMetadata.php
+++ b/src/Cache/ExecSandboxMetadata.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Cache;
+
+class ExecSandboxMetadata
+{
+    /**
+     * @param  list<string>  $packages
+     */
+    public function __construct(
+        public readonly string $key,
+        public array $packages = [],
+        public ?int $lastUpdatedAt = null,
+        public ?int $lastRunAt = null,
+    ) {}
+}

--- a/src/Cache/ExecSandboxMetadata.php
+++ b/src/Cache/ExecSandboxMetadata.php
@@ -14,7 +14,9 @@ class ExecSandboxMetadata
         public array $packages = [],
         public ?int $lastUpdatedAt = null,
         public ?int $lastRunAt = null,
-    ) {}
+    ) {
+        //
+    }
 
     public static function rootPath(): string
     {

--- a/src/Cache/ExecSandboxMetadata.php
+++ b/src/Cache/ExecSandboxMetadata.php
@@ -15,4 +15,19 @@ class ExecSandboxMetadata
         public ?int $lastUpdatedAt = null,
         public ?int $lastRunAt = null,
     ) {}
+
+    public static function rootPath(): string
+    {
+        return cpx_path('.exec_cache');
+    }
+
+    public static function pathFor(string $key): string
+    {
+        return cpx_path(".exec_cache/{$key}");
+    }
+
+    public function path(): string
+    {
+        return self::pathFor($this->key);
+    }
 }

--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -23,12 +23,10 @@ class Metadata
     /**
      * @param  array<string, PackageMetadata>  $packages
      * @param  array<string, ExecSandboxMetadata>  $execCache
-     * @param  array<string, mixed>  $aliases
      */
     protected function __construct(
         public array $packages = [],
         public array $execCache = [],
-        public array $aliases = [],
     ) {
         //
     }
@@ -82,7 +80,6 @@ class Metadata
                 },
                 is_array($json['execCache'] ?? null) ? $json['execCache'] : [],
             ),
-            aliases: is_array($json['aliases'] ?? null) ? $json['aliases'] : [],
         );
     }
 
@@ -129,7 +126,6 @@ class Metadata
     /**
      * @return array{
      *     version: int,
-     *     aliases: array<string, mixed>,
      *     packages: array<string, array{last_updated: int|null, last_run: int|null}>,
      *     execCache: array<string, array{packages: list<string>, last_updated: int|null, last_run: int|null}>
      * }
@@ -138,7 +134,6 @@ class Metadata
     {
         return [
             'version' => self::VERSION,
-            'aliases' => $this->aliases,
             'packages' => Arr::mapWithKeys(
                 fn (string $key, PackageMetadata $packageMetadata): array => [
                     $packageMetadata->package->fullPackageString() => [

--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -48,24 +48,36 @@ class Metadata
 
         return new self(
             packages: Arr::mapWithKeys(
-                fn (string $key, array $value): array => [
-                    $key => new PackageMetadata(
-                        package: Package::parse($key),
-                        lastUpdatedAt: $value['last_updated'] ?? null,
-                        lastRunAt: $value['last_run'] ?? null,
-                    ),
-                ],
+                function (string $key, mixed $value): array {
+                    if (! is_array($value)) {
+                        return [];
+                    }
+
+                    return [
+                        $key => new PackageMetadata(
+                            package: Package::parse($key),
+                            lastUpdatedAt: self::normalizeTimestamp($value['last_updated'] ?? null),
+                            lastRunAt: self::normalizeTimestamp($value['last_run'] ?? null),
+                        ),
+                    ];
+                },
                 is_array($json['packages'] ?? null) ? $json['packages'] : [],
             ),
             execCache: Arr::mapWithKeys(
-                fn (string $key, array $value): array => [
-                    $key => new ExecSandboxMetadata(
-                        key: $key,
-                        packages: is_array($value['packages'] ?? null) ? array_values($value['packages']) : [],
-                        lastUpdatedAt: $value['last_updated'] ?? null,
-                        lastRunAt: $value['last_run'] ?? null,
-                    ),
-                ],
+                function (string $key, mixed $value): array {
+                    if (! is_array($value)) {
+                        return [];
+                    }
+
+                    return [
+                        $key => new ExecSandboxMetadata(
+                            key: $key,
+                            packages: is_array($value['packages'] ?? null) ? array_values($value['packages']) : [],
+                            lastUpdatedAt: self::normalizeTimestamp($value['last_updated'] ?? null),
+                            lastRunAt: self::normalizeTimestamp($value['last_run'] ?? null),
+                        ),
+                    ];
+                },
                 is_array($json['execCache'] ?? null) ? $json['execCache'] : [],
             ),
             aliases: is_array($json['aliases'] ?? null) ? $json['aliases'] : [],
@@ -91,23 +103,16 @@ class Metadata
 
     public function recordRun(Package $package): self
     {
-        $this->forPackage($package)->lastRunAt = date('Y-m-d H:i:s');
+        $this->forPackage($package)->lastRunAt = time();
 
         return $this;
     }
 
     public function recordUpdate(Package $package): self
     {
-        $this->forPackage($package)->lastUpdatedAt = date('Y-m-d H:i:s');
+        $this->forPackage($package)->lastUpdatedAt = time();
 
         return $this;
-    }
-
-    public function save(): void
-    {
-        Lock::run(cpx_path(self::LOCK_FILE), function (): void {
-            $this->writeToDisk();
-        });
     }
 
     public function hasPackage(string|Package $package): bool
@@ -123,7 +128,7 @@ class Metadata
      * @return array{
      *     version: int,
      *     aliases: array<string, mixed>,
-     *     packages: array<string, array{last_updated: string|null, last_run: string|null}>,
+     *     packages: array<string, array{last_updated: int|null, last_run: int|null}>,
      *     execCache: array<string, array{packages: list<string>, last_updated: int|null, last_run: int|null}>
      * }
      */
@@ -162,5 +167,20 @@ class Metadata
     private function forPackage(Package $package): PackageMetadata
     {
         return $this->packages[$package->fullPackageString()] ??= new PackageMetadata($package);
+    }
+
+    private static function normalizeTimestamp(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            $timestamp = strtotime($value);
+
+            return $timestamp === false ? null : $timestamp;
+        }
+
+        return null;
     }
 }

--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -4,20 +4,31 @@ declare(strict_types=1);
 
 namespace Cpx\Cache;
 
+use Closure;
 use Cpx\Packages\Package;
 use Cpx\Support\Arr;
+use Cpx\Support\Filesystem;
+use Cpx\Support\Lock;
 
 class Metadata
 {
+    public const UPDATE_CHECK_INTERVAL = 60 * 60;
+
     private const FILE = '.cpx_metadata.json';
+
+    private const LOCK_FILE = '.cpx_metadata.lock';
+
+    private const VERSION = 2;
 
     /**
      * @param  array<string, PackageMetadata>  $packages
-     * @param  array<string, array{packages?: list<string>, last_updated?: int, last_run?: int}>  $execCache
+     * @param  array<string, ExecSandboxMetadata>  $execCache
+     * @param  array<string, mixed>  $aliases
      */
     protected function __construct(
         public array $packages = [],
         public array $execCache = [],
+        public array $aliases = [],
     ) {}
 
     public static function open(): self
@@ -46,8 +57,36 @@ class Metadata
                 ],
                 is_array($json['packages'] ?? null) ? $json['packages'] : [],
             ),
-            execCache: is_array($json['execCache'] ?? null) ? $json['execCache'] : [],
+            execCache: Arr::mapWithKeys(
+                fn (string $key, array $value): array => [
+                    $key => new ExecSandboxMetadata(
+                        key: $key,
+                        packages: is_array($value['packages'] ?? null) ? array_values($value['packages']) : [],
+                        lastUpdatedAt: $value['last_updated'] ?? null,
+                        lastRunAt: $value['last_run'] ?? null,
+                    ),
+                ],
+                is_array($json['execCache'] ?? null) ? $json['execCache'] : [],
+            ),
+            aliases: is_array($json['aliases'] ?? null) ? $json['aliases'] : [],
         );
+    }
+
+    /**
+     * @template TReturn
+     *
+     * @param  Closure(self): TReturn  $mutator
+     * @return TReturn
+     */
+    public static function transaction(Closure $mutator): mixed
+    {
+        return Lock::run(cpx_path(self::LOCK_FILE), function () use ($mutator) {
+            $metadata = self::open();
+            $result = $mutator($metadata);
+            $metadata->writeToDisk();
+
+            return $result;
+        });
     }
 
     public function recordRun(Package $package): self
@@ -66,13 +105,9 @@ class Metadata
 
     public function save(): void
     {
-        $metadataFile = cpx_path(self::FILE);
-
-        if (! is_dir(dirname($metadataFile))) {
-            mkdir(dirname($metadataFile), 0755, true);
-        }
-
-        file_put_contents($metadataFile, json_encode($this->toArray(), JSON_PRETTY_PRINT));
+        Lock::run(cpx_path(self::LOCK_FILE), function (): void {
+            $this->writeToDisk();
+        });
     }
 
     public function hasPackage(string|Package $package): bool
@@ -86,13 +121,17 @@ class Metadata
 
     /**
      * @return array{
+     *     version: int,
+     *     aliases: array<string, mixed>,
      *     packages: array<string, array{last_updated: string|null, last_run: string|null}>,
-     *     execCache: array<string, array{packages?: list<string>, last_updated?: int, last_run?: int}>
+     *     execCache: array<string, array{packages: list<string>, last_updated: int|null, last_run: int|null}>
      * }
      */
     public function toArray(): array
     {
         return [
+            'version' => self::VERSION,
+            'aliases' => $this->aliases,
             'packages' => Arr::mapWithKeys(
                 fn (string $key, PackageMetadata $packageMetadata): array => [
                     $packageMetadata->package->fullPackageString() => [
@@ -102,8 +141,22 @@ class Metadata
                 ],
                 $this->packages,
             ),
-            'execCache' => $this->execCache,
+            'execCache' => Arr::mapWithKeys(
+                fn (string $key, ExecSandboxMetadata $sandbox): array => [
+                    $sandbox->key => [
+                        'packages' => $sandbox->packages,
+                        'last_updated' => $sandbox->lastUpdatedAt,
+                        'last_run' => $sandbox->lastRunAt,
+                    ],
+                ],
+                $this->execCache,
+            ),
         ];
+    }
+
+    private function writeToDisk(): void
+    {
+        Filesystem::writeAtomic(cpx_path(self::FILE), (string) json_encode($this->toArray(), JSON_PRETTY_PRINT));
     }
 
     private function forPackage(Package $package): PackageMetadata

--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -29,7 +29,9 @@ class Metadata
         public array $packages = [],
         public array $execCache = [],
         public array $aliases = [],
-    ) {}
+    ) {
+        //
+    }
 
     public static function open(): self
     {

--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -171,18 +171,18 @@ class Metadata
         return $this->packages[$package->fullPackageString()] ??= new PackageMetadata($package);
     }
 
-    private static function normalizeTimestamp(mixed $value): ?int
+    private static function normalizeTimestamp(int|string|null $value): ?int
     {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
         if (is_int($value)) {
             return $value;
         }
 
-        if (is_string($value) && $value !== '') {
-            $timestamp = strtotime($value);
+        $timestamp = strtotime($value);
 
-            return $timestamp === false ? null : $timestamp;
-        }
-
-        return null;
+        return $timestamp === false ? null : $timestamp;
     }
 }

--- a/src/Cache/PackageMetadata.php
+++ b/src/Cache/PackageMetadata.php
@@ -10,8 +10,8 @@ class PackageMetadata
 {
     public function __construct(
         public readonly Package $package,
-        public ?string $lastUpdatedAt = null,
-        public ?string $lastRunAt = null,
+        public ?int $lastUpdatedAt = null,
+        public ?int $lastRunAt = null,
     ) {}
 
     public function installPath(): string
@@ -21,6 +21,6 @@ class PackageMetadata
 
     public function lastRunForDisplay(): string
     {
-        return $this->lastRunAt ?? 'N/A';
+        return $this->lastRunAt === null ? 'N/A' : date('Y-m-d H:i:s', $this->lastRunAt);
     }
 }

--- a/src/Cache/PackageMetadata.php
+++ b/src/Cache/PackageMetadata.php
@@ -12,7 +12,9 @@ class PackageMetadata
         public readonly Package $package,
         public ?int $lastUpdatedAt = null,
         public ?int $lastRunAt = null,
-    ) {}
+    ) {
+        //
+    }
 
     public function installPath(): string
     {

--- a/src/Cache/PackageMetadata.php
+++ b/src/Cache/PackageMetadata.php
@@ -13,4 +13,14 @@ class PackageMetadata
         public ?string $lastUpdatedAt = null,
         public ?string $lastRunAt = null,
     ) {}
+
+    public function installPath(): string
+    {
+        return $this->package->installPath();
+    }
+
+    public function lastRunForDisplay(): string
+    {
+        return $this->lastRunAt ?? 'N/A';
+    }
 }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cpx\Commands;
 
 use Cpx\Cache\Metadata;
+use Cpx\Cache\PackageMetadata;
 use Cpx\Support\Filesystem;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -58,7 +59,7 @@ class CleanCommand extends Command
         $removedAny = false;
 
         foreach ($metadata->packages as $key => $packageMetadata) {
-            if (! $all && ! $this->isStale($packageMetadata->lastRunAt, $timeLimit)) {
+            if (! $all && ! $this->isStale($packageMetadata, $timeLimit)) {
                 continue;
             }
 
@@ -145,15 +146,17 @@ class CleanCommand extends Command
         return $removedAny;
     }
 
-    private function isStale(?string $lastRunAt, int $timeLimit): bool
+    private function isStale(PackageMetadata $packageMetadata, int $timeLimit): bool
     {
-        if ($lastRunAt === null) {
+        $lastActivity = $packageMetadata->lastRunAt ?? $packageMetadata->lastUpdatedAt;
+
+        if ($lastActivity === null) {
             return true;
         }
 
-        $lastRun = strtotime($lastRunAt);
+        $timestamp = strtotime($lastActivity);
 
-        return $lastRun === false || $lastRun < $timeLimit;
+        return $timestamp === false || $timestamp < $timeLimit;
     }
 
     private function removeWithinRoot(string $path, OutputInterface $output): bool

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -7,6 +7,7 @@ namespace Cpx\Commands;
 use Cpx\Cache\ExecSandboxMetadata;
 use Cpx\Cache\Metadata;
 use Cpx\Support\Filesystem;
+use InvalidArgumentException;
 use Laravel\Prompts\Elements\Element;
 use Laravel\Prompts\Support\Logger;
 use RuntimeException;
@@ -41,18 +42,10 @@ class CleanCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $days = $input->getOption('days');
-
-        if ($days !== null) {
-            if (! is_numeric($days)) {
-                return $this->rejectInvalidDays();
-            }
-
-            $days = (int) $days;
-
-            if ($days < 0) {
-                return $this->rejectInvalidDays();
-            }
+        try {
+            $days = $this->resolveDays($input->getOption('days'));
+        } catch (InvalidArgumentException) {
+            return $this->rejectInvalidDays();
         }
 
         [$mode, $timeLimit] = $this->resolve($input, $days);
@@ -80,6 +73,25 @@ class CleanCommand extends Command
             $days !== null => [CleanMode::Period, $this->timeLimitForDays($days)],
             default => $this->promptForMode(),
         };
+    }
+
+    private function resolveDays(mixed $days): ?int
+    {
+        if ($days === null) {
+            return null;
+        }
+
+        if (! is_numeric($days)) {
+            throw new InvalidArgumentException;
+        }
+
+        $days = (int) $days;
+
+        if ($days < 1) {
+            throw new InvalidArgumentException;
+        }
+
+        return $days;
     }
 
     /**

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -87,7 +87,7 @@ class CleanCommand extends Command
 
         $days = (int) $days;
 
-        if ($days < 1) {
+        if ($days < 0) {
             throw new InvalidArgumentException;
         }
 

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Cpx\Commands;
 
 use Cpx\Cache\Metadata;
-use Cpx\Packages\Package;
 use Cpx\Support\Filesystem;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,42 +27,145 @@ class CleanCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $days = (int) $input->getOption('days');
+        $all = $input->getOption('all') === true;
+        $timeLimit = time() - ((int) $input->getOption('days') * 24 * 3600);
 
-        $metadata = Metadata::open();
-        $timeLimit = time() - ($days * 24 * 3600);
-        $cleanedSomething = false;
+        $cleaned = Metadata::transaction(
+            fn (Metadata $metadata): bool => $this->clean($metadata, $all, $timeLimit, $output),
+        );
 
-        foreach ($metadata->packages as $packageKey => $packageMetadata) {
-            $lastRun = strtotime($packageMetadata->lastRunAt ?? '1970-01-01 00:00:00');
-
-            if ($input->getOption('all') === true || $lastRun < $timeLimit) {
-                $package = Package::parse($packageKey);
-                $output->writeln("<info>Removing unused package {$package}...</info>");
-                $package->delete();
-                unset($metadata->packages[$packageKey]);
-                $cleanedSomething = true;
-            }
-        }
-
-        foreach ($metadata->execCache as $sandboxDir => $packageMetadata) {
-            $lastRun = $packageMetadata['last_run'] ?? 0;
-
-            if ($input->getOption('all') === true || $lastRun < $timeLimit) {
-                $packageDirectory = cpx_path(".exec_cache/{$sandboxDir}");
-                Filesystem::deleteDirectory($packageDirectory);
-                $output->writeln("<info>Removing exec sandbox cache {$sandboxDir}...</info>");
-                unset($metadata->execCache[$sandboxDir]);
-                $cleanedSomething = true;
-            }
-        }
-
-        $metadata->save();
-
-        if (! $cleanedSomething) {
+        if (! $cleaned) {
             $output->writeln('<info>There were no packages to clean.</info>');
         }
 
         return self::SUCCESS;
+    }
+
+    private function clean(Metadata $metadata, bool $all, int $timeLimit, OutputInterface $output): bool
+    {
+        $removed = [
+            $this->removeStalePackages($metadata, $all, $timeLimit, $output),
+            $this->removeStaleSandboxes($metadata, $all, $timeLimit, $output),
+            $this->removeOrphanPackages($metadata, $output),
+            $this->removeOrphanSandboxes($metadata, $output),
+        ];
+
+        return in_array(true, $removed);
+    }
+
+    private function removeStalePackages(Metadata $metadata, bool $all, int $timeLimit, OutputInterface $output): bool
+    {
+        $removedAny = false;
+
+        foreach ($metadata->packages as $key => $packageMetadata) {
+            if (! $all && ! $this->isStale($packageMetadata->lastRunAt, $timeLimit)) {
+                continue;
+            }
+
+            $output->writeln("<info>Removing unused package {$packageMetadata->package}...</info>");
+
+            if ($this->removeWithinRoot($packageMetadata->installPath(), $output)) {
+                unset($metadata->packages[$key]);
+                $removedAny = true;
+            }
+        }
+
+        return $removedAny;
+    }
+
+    private function removeStaleSandboxes(Metadata $metadata, bool $all, int $timeLimit, OutputInterface $output): bool
+    {
+        $removedAny = false;
+
+        foreach ($metadata->execCache as $key => $sandbox) {
+            if (! $all && ($sandbox->lastRunAt ?? 0) >= $timeLimit) {
+                continue;
+            }
+
+            $output->writeln("<info>Removing exec sandbox cache {$key}...</info>");
+
+            if ($this->removeWithinRoot(cpx_path(".exec_cache/{$key}"), $output)) {
+                unset($metadata->execCache[$key]);
+                $removedAny = true;
+            }
+        }
+
+        return $removedAny;
+    }
+
+    private function removeOrphanPackages(Metadata $metadata, OutputInterface $output): bool
+    {
+        $tracked = [];
+
+        foreach ($metadata->packages as $key => $packageMetadata) {
+            $tracked[$packageMetadata->installPath()] = $key;
+        }
+
+        $removedAny = false;
+
+        foreach (glob(cpx_path('*/*/*'), GLOB_ONLYDIR) ?: [] as $directory) {
+            $trackedKey = $tracked[$directory] ?? null;
+
+            if ($trackedKey !== null && file_exists("{$directory}/vendor/autoload.php")) {
+                continue;
+            }
+
+            $output->writeln('<info>Removing orphaned package cache '.str_replace(cpx_path(), '', $directory).'...</info>');
+
+            if (! $this->removeWithinRoot($directory, $output)) {
+                continue;
+            }
+
+            if ($trackedKey !== null) {
+                unset($metadata->packages[$trackedKey]);
+            }
+
+            $removedAny = true;
+        }
+
+        return $removedAny;
+    }
+
+    private function removeOrphanSandboxes(Metadata $metadata, OutputInterface $output): bool
+    {
+        $removedAny = false;
+
+        foreach (glob(cpx_path('.exec_cache/*'), GLOB_ONLYDIR) ?: [] as $directory) {
+            if (array_key_exists(basename($directory), $metadata->execCache)) {
+                continue;
+            }
+
+            $output->writeln('<info>Removing orphaned exec sandbox cache '.basename($directory).'...</info>');
+
+            if ($this->removeWithinRoot($directory, $output)) {
+                $removedAny = true;
+            }
+        }
+
+        return $removedAny;
+    }
+
+    private function isStale(?string $lastRunAt, int $timeLimit): bool
+    {
+        if ($lastRunAt === null) {
+            return true;
+        }
+
+        $lastRun = strtotime($lastRunAt);
+
+        return $lastRun === false || $lastRun < $timeLimit;
+    }
+
+    private function removeWithinRoot(string $path, OutputInterface $output): bool
+    {
+        try {
+            Filesystem::deleteDirectoryWithin($path, cpx_path());
+
+            return true;
+        } catch (RuntimeException $exception) {
+            $output->writeln("<error>{$exception->getMessage()}</error>");
+
+            return false;
+        }
     }
 }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -219,6 +219,7 @@ class CleanCommand extends Command
 
         try {
             Filesystem::deleteDirectoryWithin($path, cpx_path());
+            Filesystem::pruneEmptyParents($path, cpx_path());
 
             $result->recordRemoval($description);
 

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cpx\Commands;
 
+use Cpx\Cache\ExecSandboxMetadata;
 use Cpx\Cache\Metadata;
-use Cpx\Cache\PackageMetadata;
 use Cpx\Support\Filesystem;
 use Laravel\Prompts\Elements\Element;
 use Laravel\Prompts\Support\Logger;
@@ -66,7 +66,7 @@ class CleanCommand extends Command
 
         $this->renderSummary($result);
 
-        return self::SUCCESS;
+        return $result->hasFailures() ? self::FAILURE : self::SUCCESS;
     }
 
     /**
@@ -131,7 +131,7 @@ class CleanCommand extends Command
     private function removeStalePackages(Metadata $metadata, bool $removeAll, int $timeLimit, CleanResult $result, Logger $logger): void
     {
         foreach ($metadata->packages as $key => $packageMetadata) {
-            if (! $removeAll && ! $this->isStale($packageMetadata, $timeLimit)) {
+            if (! $removeAll && ! $this->isStale($packageMetadata->lastRunAt, $packageMetadata->lastUpdatedAt, $timeLimit)) {
                 continue;
             }
 
@@ -146,11 +146,11 @@ class CleanCommand extends Command
     private function removeStaleSandboxes(Metadata $metadata, bool $removeAll, int $timeLimit, CleanResult $result, Logger $logger): void
     {
         foreach ($metadata->execCache as $key => $sandbox) {
-            if (! $removeAll && ($sandbox->lastRunAt ?? 0) >= $timeLimit) {
+            if (! $removeAll && ! $this->isStale($sandbox->lastRunAt, $sandbox->lastUpdatedAt, $timeLimit)) {
                 continue;
             }
 
-            if ($this->remove(cpx_path(".exec_cache/{$key}"), "exec sandbox {$key}", $result, $logger)) {
+            if ($this->remove($sandbox->path(), "exec sandbox {$key}", $result, $logger)) {
                 unset($metadata->execCache[$key]);
             }
         }
@@ -185,7 +185,7 @@ class CleanCommand extends Command
 
     private function removeOrphanSandboxes(Metadata $metadata, CleanResult $result, Logger $logger): void
     {
-        foreach (glob(cpx_path('.exec_cache/*'), GLOB_ONLYDIR) ?: [] as $directory) {
+        foreach (glob(ExecSandboxMetadata::rootPath().'/*', GLOB_ONLYDIR) ?: [] as $directory) {
             if (array_key_exists(basename($directory), $metadata->execCache)) {
                 continue;
             }
@@ -194,17 +194,11 @@ class CleanCommand extends Command
         }
     }
 
-    private function isStale(PackageMetadata $packageMetadata, int $timeLimit): bool
+    private function isStale(?int $lastRunAt, ?int $lastUpdatedAt, int $timeLimit): bool
     {
-        $lastActivity = $packageMetadata->lastRunAt ?? $packageMetadata->lastUpdatedAt;
+        $lastActivity = $lastRunAt ?? $lastUpdatedAt;
 
-        if ($lastActivity === null) {
-            return true;
-        }
-
-        $timestamp = strtotime($lastActivity);
-
-        return $timestamp === false || $timestamp < $timeLimit;
+        return $lastActivity === null || $lastActivity < $timeLimit;
     }
 
     private function remove(string $path, string $description, CleanResult $result, Logger $logger): bool

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class CleanCommand extends Command
 {
+    private const SECONDS_PER_DAY = 24 * 60 * 60;
+
     protected function configure(): void
     {
         $this->addOption('all', null, InputOption::VALUE_NONE, 'Clean all packages');
@@ -29,7 +31,7 @@ class CleanCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $all = $input->getOption('all') === true;
-        $timeLimit = time() - ((int) $input->getOption('days') * 24 * 3600);
+        $timeLimit = time() - ((int) $input->getOption('days') * self::SECONDS_PER_DAY);
 
         $cleaned = Metadata::transaction(
             fn (Metadata $metadata): bool => $this->clean($metadata, $all, $timeLimit, $output),

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -7,12 +7,20 @@ namespace Cpx\Commands;
 use Cpx\Cache\Metadata;
 use Cpx\Cache\PackageMetadata;
 use Cpx\Support\Filesystem;
+use Laravel\Prompts\Elements\Element;
+use Laravel\Prompts\Support\Logger;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\callout;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\number;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\task;
 
 #[AsCommand(
     name: 'clean',
@@ -22,89 +30,139 @@ class CleanCommand extends Command
 {
     private const SECONDS_PER_DAY = 24 * 60 * 60;
 
+    private const DEFAULT_DAYS = 30;
+
     protected function configure(): void
     {
-        $this->addOption('all', null, InputOption::VALUE_NONE, 'Clean all packages');
-        $this->addOption('days', null, InputOption::VALUE_REQUIRED, 'Clean packages older than this number of days', '30');
+        $this->addOption('all', null, InputOption::VALUE_NONE, 'Clean all cached packages and sandboxes');
+        $this->addOption('sandbox', null, InputOption::VALUE_NONE, 'Clean only sandbox (exec) caches');
+        $this->addOption('days', null, InputOption::VALUE_REQUIRED, 'Clean packages older than this number of days');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $all = $input->getOption('all') === true;
-        $timeLimit = time() - ((int) $input->getOption('days') * self::SECONDS_PER_DAY);
+        $days = $input->getOption('days');
 
-        $cleaned = Metadata::transaction(
-            fn (Metadata $metadata): bool => $this->clean($metadata, $all, $timeLimit, $output),
+        if ($days !== null) {
+            if (! is_numeric($days)) {
+                return $this->rejectInvalidDays();
+            }
+
+            $days = (int) $days;
+
+            if ($days < 0) {
+                return $this->rejectInvalidDays();
+            }
+        }
+
+        [$mode, $timeLimit] = $this->resolve($input, $days);
+
+        $result = task(
+            label: 'Cleaning cpx caches',
+            callback: fn (Logger $logger): CleanResult => Metadata::transaction(
+                fn (Metadata $metadata): CleanResult => $this->clean($metadata, $mode, $timeLimit, $logger),
+            ),
         );
 
-        if (! $cleaned) {
-            $output->writeln('<info>There were no packages to clean.</info>');
-        }
+        $this->renderSummary($result);
 
         return self::SUCCESS;
     }
 
-    private function clean(Metadata $metadata, bool $all, int $timeLimit, OutputInterface $output): bool
+    /**
+     * @return array{0: CleanMode, 1: int}
+     */
+    private function resolve(InputInterface $input, ?int $days): array
     {
-        $removed = [
-            $this->removeStalePackages($metadata, $all, $timeLimit, $output),
-            $this->removeStaleSandboxes($metadata, $all, $timeLimit, $output),
-            $this->removeOrphanPackages($metadata, $output),
-            $this->removeOrphanSandboxes($metadata, $output),
-        ];
-
-        return in_array(true, $removed);
+        return match (true) {
+            $input->getOption('all') === true => [CleanMode::All, $this->timeLimitForDays(self::DEFAULT_DAYS)],
+            $input->getOption('sandbox') === true => [CleanMode::Sandbox, $this->timeLimitForDays(self::DEFAULT_DAYS)],
+            $days !== null => [CleanMode::Period, $this->timeLimitForDays($days)],
+            default => $this->promptForMode(),
+        };
     }
 
-    private function removeStalePackages(Metadata $metadata, bool $all, int $timeLimit, OutputInterface $output): bool
+    /**
+     * @return array{0: CleanMode, 1: int}
+     */
+    private function promptForMode(): array
     {
-        $removedAny = false;
+        $choice = select(
+            label: 'What would you like to clean?',
+            options: [
+                'all' => 'All cached packages and sandboxes',
+                'sandbox' => 'Only sandbox (exec) caches',
+                'period' => 'Packages older than a number of days',
+            ],
+            default: 'period',
+        );
 
+        return match ($choice) {
+            'all' => [CleanMode::All, $this->timeLimitForDays(self::DEFAULT_DAYS)],
+            'sandbox' => [CleanMode::Sandbox, $this->timeLimitForDays(self::DEFAULT_DAYS)],
+            default => [CleanMode::Period, $this->timeLimitForDays($this->promptForDays())],
+        };
+    }
+
+    private function promptForDays(): int
+    {
+        return (int) number(
+            label: 'Remove packages older than how many days?',
+            default: (string) self::DEFAULT_DAYS,
+            min: 1,
+        );
+    }
+
+    private function clean(Metadata $metadata, CleanMode $mode, int $timeLimit, Logger $logger): CleanResult
+    {
+        $result = new CleanResult;
+
+        if ($mode->cleansPackages()) {
+            $this->removeStalePackages($metadata, $mode->removesAllPackages(), $timeLimit, $result, $logger);
+            $this->removeOrphanPackages($metadata, $result, $logger);
+        }
+
+        $this->removeStaleSandboxes($metadata, $mode->removesAllSandboxes(), $timeLimit, $result, $logger);
+        $this->removeOrphanSandboxes($metadata, $result, $logger);
+
+        return $result;
+    }
+
+    private function removeStalePackages(Metadata $metadata, bool $removeAll, int $timeLimit, CleanResult $result, Logger $logger): void
+    {
         foreach ($metadata->packages as $key => $packageMetadata) {
-            if (! $all && ! $this->isStale($packageMetadata, $timeLimit)) {
+            if (! $removeAll && ! $this->isStale($packageMetadata, $timeLimit)) {
                 continue;
             }
 
-            $output->writeln("<info>Removing unused package {$packageMetadata->package}...</info>");
+            $description = "package {$packageMetadata->package->fullPackageString()}";
 
-            if ($this->removeWithinRoot($packageMetadata->installPath(), $output)) {
+            if ($this->remove($packageMetadata->installPath(), $description, $result, $logger)) {
                 unset($metadata->packages[$key]);
-                $removedAny = true;
             }
         }
-
-        return $removedAny;
     }
 
-    private function removeStaleSandboxes(Metadata $metadata, bool $all, int $timeLimit, OutputInterface $output): bool
+    private function removeStaleSandboxes(Metadata $metadata, bool $removeAll, int $timeLimit, CleanResult $result, Logger $logger): void
     {
-        $removedAny = false;
-
         foreach ($metadata->execCache as $key => $sandbox) {
-            if (! $all && ($sandbox->lastRunAt ?? 0) >= $timeLimit) {
+            if (! $removeAll && ($sandbox->lastRunAt ?? 0) >= $timeLimit) {
                 continue;
             }
 
-            $output->writeln("<info>Removing exec sandbox cache {$key}...</info>");
-
-            if ($this->removeWithinRoot(cpx_path(".exec_cache/{$key}"), $output)) {
+            if ($this->remove(cpx_path(".exec_cache/{$key}"), "exec sandbox {$key}", $result, $logger)) {
                 unset($metadata->execCache[$key]);
-                $removedAny = true;
             }
         }
-
-        return $removedAny;
     }
 
-    private function removeOrphanPackages(Metadata $metadata, OutputInterface $output): bool
+    private function removeOrphanPackages(Metadata $metadata, CleanResult $result, Logger $logger): void
     {
         $tracked = [];
 
         foreach ($metadata->packages as $key => $packageMetadata) {
             $tracked[$packageMetadata->installPath()] = $key;
         }
-
-        $removedAny = false;
 
         foreach (glob(cpx_path('*/*/*'), GLOB_ONLYDIR) ?: [] as $directory) {
             $trackedKey = $tracked[$directory] ?? null;
@@ -113,39 +171,27 @@ class CleanCommand extends Command
                 continue;
             }
 
-            $output->writeln('<info>Removing orphaned package cache '.str_replace(cpx_path(), '', $directory).'...</info>');
+            $description = 'orphaned package '.str_replace(cpx_path(), '', $directory);
 
-            if (! $this->removeWithinRoot($directory, $output)) {
+            if (! $this->remove($directory, $description, $result, $logger)) {
                 continue;
             }
 
             if ($trackedKey !== null) {
                 unset($metadata->packages[$trackedKey]);
             }
-
-            $removedAny = true;
         }
-
-        return $removedAny;
     }
 
-    private function removeOrphanSandboxes(Metadata $metadata, OutputInterface $output): bool
+    private function removeOrphanSandboxes(Metadata $metadata, CleanResult $result, Logger $logger): void
     {
-        $removedAny = false;
-
         foreach (glob(cpx_path('.exec_cache/*'), GLOB_ONLYDIR) ?: [] as $directory) {
             if (array_key_exists(basename($directory), $metadata->execCache)) {
                 continue;
             }
 
-            $output->writeln('<info>Removing orphaned exec sandbox cache '.basename($directory).'...</info>');
-
-            if ($this->removeWithinRoot($directory, $output)) {
-                $removedAny = true;
-            }
+            $this->remove($directory, 'orphaned exec sandbox '.basename($directory), $result, $logger);
         }
-
-        return $removedAny;
     }
 
     private function isStale(PackageMetadata $packageMetadata, int $timeLimit): bool
@@ -161,16 +207,60 @@ class CleanCommand extends Command
         return $timestamp === false || $timestamp < $timeLimit;
     }
 
-    private function removeWithinRoot(string $path, OutputInterface $output): bool
+    private function remove(string $path, string $description, CleanResult $result, Logger $logger): bool
     {
+        $logger->line("Removing {$description}...");
+
         try {
             Filesystem::deleteDirectoryWithin($path, cpx_path());
 
+            $result->recordRemoval($description);
+
             return true;
         } catch (RuntimeException $exception) {
-            $output->writeln("<error>{$exception->getMessage()}</error>");
+            $logger->warning($exception->getMessage());
+            $result->recordFailure($exception->getMessage());
 
             return false;
         }
+    }
+
+    private function renderSummary(CleanResult $result): void
+    {
+        if ($result->isEmpty()) {
+            callout(label: 'Clean Summary', content: 'Nothing to clean.');
+
+            return;
+        }
+
+        $content = [];
+
+        if ($result->removed !== []) {
+            $content[] = Element::heading('Removed');
+            $content[] = Element::bulletedList($result->removed);
+        }
+
+        if ($result->failures !== []) {
+            $content[] = Element::heading('Could not remove');
+            $content[] = Element::bulletedList($result->failures);
+        }
+
+        callout(
+            label: 'Clean Summary',
+            content: $content,
+            type: $result->hasFailures() ? 'warning' : null,
+        );
+    }
+
+    private function timeLimitForDays(int $days): int
+    {
+        return time() - ($days * self::SECONDS_PER_DAY);
+    }
+
+    private function rejectInvalidDays(): int
+    {
+        error('The --days option must be a positive integer.');
+
+        return self::INVALID;
     }
 }

--- a/src/Commands/CleanMode.php
+++ b/src/Commands/CleanMode.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Commands;
+
+enum CleanMode
+{
+    case All;
+    case Sandbox;
+    case Period;
+
+    public function cleansPackages(): bool
+    {
+        return $this !== self::Sandbox;
+    }
+
+    public function removesAllPackages(): bool
+    {
+        return $this === self::All;
+    }
+
+    public function removesAllSandboxes(): bool
+    {
+        return $this !== self::Period;
+    }
+}

--- a/src/Commands/CleanResult.php
+++ b/src/Commands/CleanResult.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Commands;
+
+class CleanResult
+{
+    /** @var list<string> */
+    public array $removed = [];
+
+    /** @var list<string> */
+    public array $failures = [];
+
+    public function recordRemoval(string $description): void
+    {
+        $this->removed[] = $description;
+    }
+
+    public function recordFailure(string $message): void
+    {
+        $this->failures[] = $message;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->removed === [] && $this->failures === [];
+    }
+
+    public function hasFailures(): bool
+    {
+        return $this->failures !== [];
+    }
+}

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -38,7 +38,9 @@ class ExecCommand extends Command
         } finally {
             $contents = ob_get_clean();
 
-            $output->write($contents);
+            if ($contents !== false) {
+                $output->write($contents);
+            }
         }
     }
 

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -38,9 +38,7 @@ class ExecCommand extends Command
         } finally {
             $contents = ob_get_clean();
 
-            if ($contents !== false) {
-                $output->write($contents);
-            }
+            $output->write($contents);
         }
     }
 

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -28,8 +28,8 @@ class ListCommand extends Command
 
         $output->writeln('Installed Packages:');
 
-        foreach ($metadata->packages as $packageKey => $packageMetadata) {
-            $output->writeln("<info>  {$packageMetadata->package->fullPackageString()}</info> (Last Run: ".($packageMetadata->lastRunAt ?? 'N/A').')');
+        foreach ($metadata->packages as $packageMetadata) {
+            $output->writeln("<info>  {$packageMetadata->package->fullPackageString()}</info> (Last Run: {$packageMetadata->lastRunForDisplay()})");
         }
 
         return self::SUCCESS;

--- a/src/Packages/ExecSandbox.php
+++ b/src/Packages/ExecSandbox.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Packages;
+
+use Cpx\Cache\ExecSandboxMetadata;
+use Cpx\Cache\Metadata;
+use Cpx\Composer\ComposerRunner;
+use Cpx\Exceptions\ComposerInstallException;
+use Cpx\Runtime\PhpExecutionHelper;
+use Cpx\Support\Filesystem;
+use stdClass;
+use Throwable;
+
+class ExecSandbox
+{
+    /**
+     * @param  list<string>  $packages
+     */
+    protected function __construct(
+        public string $key,
+        public array $packages,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string>  $packages
+     */
+    public static function forPackages(array $packages): self
+    {
+        sort($packages);
+
+        return new self(hash('sha256', implode(' ', $packages)), $packages);
+    }
+
+    public function path(): string
+    {
+        return ExecSandboxMetadata::pathFor($this->key);
+    }
+
+    public function isInstalled(): bool
+    {
+        return file_exists($this->path().'/vendor/autoload.php');
+    }
+
+    public function load(): void
+    {
+        $updatedAt = match (true) {
+            ! $this->isInstalled() => $this->install(),
+            $this->shouldCheckForUpdates() => $this->update(),
+            default => null,
+        };
+
+        $autoloadFile = $this->path().'/vendor/autoload.php';
+
+        if (! file_exists($autoloadFile)) {
+            throw new ComposerInstallException("Autoload file not found in {$this->path()}/vendor/. Composer installation may have failed.");
+        }
+
+        $this->record($updatedAt);
+
+        if (isset(PhpExecutionHelper::$classAliasAutoloader)) {
+            PhpExecutionHelper::$classAliasAutoloader->addAliases($this->path());
+        }
+
+        require_once $autoloadFile;
+    }
+
+    private function install(): int
+    {
+        $cacheRoot = cpx_path();
+        Filesystem::ensureDirectory($cacheRoot);
+
+        $stagingDir = $this->path().'.installing.'.getmypid();
+        $this->stageInstall($stagingDir, $cacheRoot);
+
+        Filesystem::deleteDirectory($this->path());
+
+        if (! rename($stagingDir, $this->path())) {
+            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+
+            throw new ComposerInstallException("Unable to finalize the exec sandbox for {$this->key}.");
+        }
+
+        return time();
+    }
+
+    private function stageInstall(string $stagingDir, string $cacheRoot): void
+    {
+        Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+        Filesystem::ensureDirectory($stagingDir);
+
+        file_put_contents("{$stagingDir}/composer.json", json_encode([
+            'require' => new stdClass,
+            'config' => [
+                'vendor-dir' => './vendor',
+            ],
+        ], JSON_PRETTY_PRINT));
+
+        foreach ($this->packages as $package) {
+            try {
+                ComposerRunner::run(['require', $package], $stagingDir);
+            } catch (Throwable $exception) {
+                Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+
+                throw new ComposerInstallException("Failed to install package: {$package}.", previous: $exception);
+            }
+        }
+    }
+
+    private function update(): ?int
+    {
+        try {
+            ComposerRunner::run(['update'], $this->path());
+
+            return time();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function shouldCheckForUpdates(): bool
+    {
+        $lastUpdatedAt = (Metadata::open()->execCache[$this->key] ?? null)?->lastUpdatedAt;
+
+        if ($lastUpdatedAt === null) {
+            return true;
+        }
+
+        return (time() - $lastUpdatedAt) > Metadata::UPDATE_CHECK_INTERVAL;
+    }
+
+    private function record(?int $updatedAt): void
+    {
+        Metadata::transaction(function (Metadata $metadata) use ($updatedAt): void {
+            $sandbox = $metadata->execCache[$this->key] ?? new ExecSandboxMetadata(key: $this->key);
+            $sandbox->packages = $this->packages;
+            $sandbox->lastRunAt = time();
+
+            if ($updatedAt !== null) {
+                $sandbox->lastUpdatedAt = $updatedAt;
+            }
+
+            $metadata->execCache[$this->key] = $sandbox;
+        });
+    }
+}

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -156,9 +156,7 @@ class Package
             return true;
         }
 
-        $lastCheck = strtotime($lastUpdatedAt);
-
-        return $lastCheck === false || (time() - $lastCheck) > Metadata::UPDATE_CHECK_INTERVAL;
+        return (time() - $lastUpdatedAt) > Metadata::UPDATE_CHECK_INTERVAL;
     }
 
     /**
@@ -208,10 +206,7 @@ class Package
         $output->writeln("<info>Installing {$this}...</info>");
 
         $cacheRoot = cpx_path();
-
-        if (! is_dir($cacheRoot)) {
-            mkdir($cacheRoot, 0755, true);
-        }
+        Filesystem::ensureDirectory($cacheRoot);
 
         $stagingDir = "{$installDir}.installing.".getmypid();
         $this->stageInstall($stagingDir, $cacheRoot);
@@ -230,7 +225,7 @@ class Package
     private function stageInstall(string $stagingDir, string $cacheRoot): void
     {
         Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-        mkdir($stagingDir, 0755, true);
+        Filesystem::ensureDirectory($stagingDir);
 
         file_put_contents("{$stagingDir}/composer.json", json_encode([
             'name' => "cpx-{$this->vendor}/cpx-{$this->name}",

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -11,8 +11,10 @@ use Cpx\Process\ProcessRunner;
 use Cpx\Support\Arr;
 use Cpx\Support\Filesystem;
 use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class Package
 {
@@ -22,8 +24,6 @@ class Package
     private const PACKAGE_PATTERN = '/\A(?<vendor>[a-z0-9](?:[_.-]?[a-z0-9]+)*)\/(?<name>[a-z0-9](?:(?:[_.]?|-{0,2})[a-z0-9]+)*)(?::(?<version>(?![.]+\z)[a-zA-Z0-9_.@~^*<>!=|,-]+))?\z/';
 
     private const SCAFFOLD_VERSION = '1.0.0';
-
-    private const UPDATE_CHECK_INTERVAL = 60 * 60;
 
     protected function __construct(
         public string $vendor,
@@ -60,9 +60,21 @@ class Package
         return "{$this->vendor}/{$this->name}/{$this->versionName()}";
     }
 
+    public function installPath(): string
+    {
+        return cpx_path($this->folder());
+    }
+
     public function versionName(): string
     {
-        return $this->version ?? 'latest';
+        if ($this->version === null) {
+            return 'latest';
+        }
+
+        $slug = trim((string) preg_replace('/[^a-z0-9_.]+/i', '-', $this->version), '-');
+        $suffix = substr(hash('sha256', $this->version), 0, 12);
+
+        return $slug === '' ? $suffix : "{$slug}-{$suffix}";
     }
 
     public function fullPackageString(): string
@@ -73,7 +85,7 @@ class Package
 
     public function delete(): void
     {
-        Filesystem::deleteDirectory(cpx_path($this->folder()));
+        Filesystem::deleteDirectory($this->installPath());
     }
 
     public function runCommand(PackageInvocation $invocation, OutputInterface $output, bool $autoUpdate = true): int
@@ -105,7 +117,7 @@ class Package
             return Command::FAILURE;
         }
 
-        Metadata::open()->recordRun($this)->save();
+        Metadata::transaction(fn (Metadata $metadata) => $metadata->recordRun($this));
         $output->writeln('<info>Running '.basename($resolved->command)." from {$this}</info>");
 
         return (new ProcessRunner)->run([$binPath, ...$resolved->invocation->forwardedTokens()]);
@@ -113,19 +125,20 @@ class Package
 
     public function installOrUpdatePackage(OutputInterface $output, bool $updateCheck = true): string
     {
-        $installDir = cpx_path($this->folder());
-
-        if (! is_dir($installDir)) {
-            mkdir($installDir, 0755, true);
-        }
+        $installDir = $this->installPath();
 
         match (true) {
-            ! is_dir("{$installDir}/vendor") => $this->installPackage($output, $installDir),
+            ! $this->isInstalled() => $this->installPackage($output, $installDir),
             $updateCheck && $this->shouldCheckForUpdates() => $this->updatePackage($output, $installDir),
             default => $output->writeln("<info>{$this} is already installed and doesn't need updating.</info>"),
         };
 
         return $installDir;
+    }
+
+    public function isInstalled(): bool
+    {
+        return file_exists($this->installPath().'/vendor/autoload.php');
     }
 
     public function shouldCheckForUpdates(): bool
@@ -145,7 +158,7 @@ class Package
 
         $lastCheck = strtotime($lastUpdatedAt);
 
-        return $lastCheck === false || (time() - $lastCheck) > self::UPDATE_CHECK_INTERVAL;
+        return $lastCheck === false || (time() - $lastCheck) > Metadata::UPDATE_CHECK_INTERVAL;
     }
 
     /**
@@ -193,7 +206,33 @@ class Package
     private function installPackage(OutputInterface $output, string $installDir): void
     {
         $output->writeln("<info>Installing {$this}...</info>");
-        file_put_contents("{$installDir}/composer.json", json_encode([
+
+        $cacheRoot = cpx_path();
+
+        if (! is_dir($cacheRoot)) {
+            mkdir($cacheRoot, 0755, true);
+        }
+
+        $stagingDir = "{$installDir}.installing.".getmypid();
+        $this->stageInstall($stagingDir, $cacheRoot);
+
+        Filesystem::deleteDirectory($installDir);
+
+        if (! rename($stagingDir, $installDir)) {
+            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+
+            throw new RuntimeException("Unable to finalize the installation of {$this}.");
+        }
+
+        Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate($this));
+    }
+
+    private function stageInstall(string $stagingDir, string $cacheRoot): void
+    {
+        Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+        mkdir($stagingDir, 0755, true);
+
+        file_put_contents("{$stagingDir}/composer.json", json_encode([
             'name' => "cpx-{$this->vendor}/cpx-{$this->name}",
             'version' => self::SCAFFOLD_VERSION,
             'config' => [
@@ -202,8 +241,13 @@ class Package
             ],
         ]));
 
-        ComposerRunner::run(['require', $this->fullPackageString()], $installDir);
-        Metadata::open()->recordUpdate($this)->save();
+        try {
+            ComposerRunner::run(['require', $this->fullPackageString()], $stagingDir);
+        } catch (Throwable $exception) {
+            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+
+            throw $exception;
+        }
     }
 
     private function updatePackage(OutputInterface $output, string $installDir): void
@@ -219,6 +263,6 @@ class Package
             $output->writeln("<info>{$this} is already up-to-date.</info>");
         }
 
-        Metadata::open()->recordUpdate($this)->save();
+        Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate($this));
     }
 }

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -12,6 +12,53 @@ use SplFileInfo;
 
 class Filesystem
 {
+    public static function writeAtomic(string $path, string $contents): void
+    {
+        $directory = dirname($path);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $temporaryPath = $path.'.'.getmypid().'.tmp';
+
+        if (file_put_contents($temporaryPath, $contents) === false) {
+            self::deleteFile($temporaryPath);
+
+            throw new RuntimeException("Unable to write to {$temporaryPath}.");
+        }
+
+        if (! rename($temporaryPath, $path)) {
+            self::deleteFile($temporaryPath);
+
+            throw new RuntimeException("Unable to move {$temporaryPath} to {$path}.");
+        }
+    }
+
+    public static function deleteDirectoryWithin(string $path, string $root): void
+    {
+        $resolvedRoot = realpath($root);
+
+        if ($resolvedRoot === false) {
+            throw new RuntimeException("Cache root {$root} does not exist.");
+        }
+
+        $resolvedPath = realpath($path);
+
+        if ($resolvedPath === false) {
+            return;
+        }
+
+        if (
+            $resolvedPath !== $resolvedRoot &&
+            ! str_starts_with($resolvedPath, $resolvedRoot.DIRECTORY_SEPARATOR)
+        ) {
+            throw new RuntimeException("Refusing to delete {$path} outside of the cpx cache root.");
+        }
+
+        self::deleteDirectory($resolvedPath);
+    }
+
     public static function deleteDirectory(string $directory): void
     {
         if (! is_dir($directory)) {
@@ -35,6 +82,13 @@ class Filesystem
 
         if (! rmdir($directory)) {
             throw new RuntimeException("Unable to remove directory {$directory}.");
+        }
+    }
+
+    private static function deleteFile(string $path): void
+    {
+        if (file_exists($path)) {
+            unlink($path);
         }
     }
 }

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -12,13 +12,20 @@ use SplFileInfo;
 
 class Filesystem
 {
+    public static function ensureDirectory(string $directory): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+
+        if (! @mkdir($directory, 0755, true) && ! is_dir($directory)) {
+            throw new RuntimeException("Unable to create directory {$directory}.");
+        }
+    }
+
     public static function writeAtomic(string $path, string $contents): void
     {
-        $directory = dirname($path);
-
-        if (! is_dir($directory)) {
-            mkdir($directory, 0755, true);
-        }
+        self::ensureDirectory(dirname($path));
 
         $temporaryPath = $path.'.'.getmypid().'.tmp';
 

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -66,6 +66,29 @@ class Filesystem
         self::deleteDirectory($resolvedPath);
     }
 
+    public static function pruneEmptyParents(string $path, string $root): void
+    {
+        $resolvedRoot = realpath($root);
+
+        if ($resolvedRoot === false) {
+            return;
+        }
+
+        $parent = realpath(dirname($path));
+
+        while (
+            $parent !== false &&
+            $parent !== $resolvedRoot &&
+            str_starts_with($parent, $resolvedRoot.DIRECTORY_SEPARATOR)
+        ) {
+            if (! @rmdir($parent)) {
+                return;
+            }
+
+            $parent = realpath(dirname($parent));
+        }
+    }
+
     public static function deleteDirectory(string $directory): void
     {
         if (! is_dir($directory)) {

--- a/src/Support/Lock.php
+++ b/src/Support/Lock.php
@@ -17,11 +17,7 @@ class Lock
      */
     public static function run(string $path, Closure $callback): mixed
     {
-        $directory = dirname($path);
-
-        if (! is_dir($directory)) {
-            mkdir($directory, 0755, true);
-        }
+        Filesystem::ensureDirectory(dirname($path));
 
         $handle = fopen($path, 'c');
 

--- a/src/Support/Lock.php
+++ b/src/Support/Lock.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Support;
+
+use Closure;
+use RuntimeException;
+
+class Lock
+{
+    /**
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function run(string $path, Closure $callback): mixed
+    {
+        $directory = dirname($path);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $handle = fopen($path, 'c');
+
+        if ($handle === false) {
+            throw new RuntimeException("Unable to open lock file {$path}.");
+        }
+
+        try {
+            if (! flock($handle, LOCK_EX)) {
+                throw new RuntimeException("Unable to acquire lock on {$path}.");
+            }
+
+            return $callback();
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Cpx\Cache\ExecSandboxMetadata;
 use Cpx\Cache\Metadata;
 use Cpx\Composer\ComposerRunner;
 use Cpx\Exceptions\ComposerInstallException;
@@ -19,10 +20,10 @@ if (! function_exists('composer_require')) {
     {
         sort($packages);
 
-        $hash = hash('sha256', implode(' ', $packages));
-        $sandboxDir = cpx_path(".exec_cache/{$hash}");
+        $key = hash('sha256', implode(' ', $packages));
+        $sandboxDir = cpx_path(".exec_cache/{$key}");
 
-        $metadata = Metadata::open();
+        $sandbox = Metadata::open()->execCache[$key] ?? new ExecSandboxMetadata(key: $key);
 
         if (! is_dir($sandboxDir)) {
             mkdir($sandboxDir, 0755, true);
@@ -34,30 +35,29 @@ if (! function_exists('composer_require')) {
                 ],
             ], JSON_PRETTY_PRINT));
 
-            // Run `composer require` for each package
             foreach ($packages as $package) {
                 try {
                     ComposerRunner::run(['require', $package], $sandboxDir);
-                    $metadata->execCache[$hash]['last_updated'] = time();
-                } catch (Exception $e) {
+                    $sandbox->lastUpdatedAt = time();
+                } catch (Exception) {
                     throw new ComposerInstallException("Failed to install package: {$package}.");
                 }
             }
-        } else {
-            if (isset($metadata->execCache[$hash]['last_updated']) && time() - $metadata->execCache[$hash]['last_updated'] >= 3600) {
-                // Composer update was not run within the last hour
-                try {
-                    ComposerRunner::run(['update'], $sandboxDir);
-                    $metadata->execCache[$hash]['last_updated'] = time();
-                } catch (Exception $e) {
-                    // Update failed, let's just use the existing folder.
-                }
+        } elseif ($sandbox->lastUpdatedAt !== null && time() - $sandbox->lastUpdatedAt >= Metadata::UPDATE_CHECK_INTERVAL) {
+            try {
+                ComposerRunner::run(['update'], $sandboxDir);
+                $sandbox->lastUpdatedAt = time();
+            } catch (Exception) {
+                // Update failed, keep using the existing sandbox.
             }
         }
 
-        $metadata->execCache[$hash]['packages'] = $packages;
-        $metadata->execCache[$hash]['last_run'] = time();
-        $metadata->save();
+        $sandbox->packages = $packages;
+        $sandbox->lastRunAt = time();
+
+        Metadata::transaction(function (Metadata $metadata) use ($key, $sandbox): void {
+            $metadata->execCache[$key] = $sandbox;
+        });
 
         $autoloadFile = "{$sandboxDir}/vendor/autoload.php";
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,11 +2,8 @@
 
 declare(strict_types=1);
 
-use Cpx\Cache\ExecSandboxMetadata;
-use Cpx\Cache\Metadata;
-use Cpx\Composer\ComposerRunner;
 use Cpx\Exceptions\ComposerInstallException;
-use Cpx\Runtime\PhpExecutionHelper;
+use Cpx\Packages\ExecSandbox;
 
 if (! function_exists('composer_require')) {
     /**
@@ -14,62 +11,11 @@ if (! function_exists('composer_require')) {
      *
      * @param  string  ...$packages  List of packages to require in the format vendor/package[:version].
      *
-     * @throws Exception If the Composer require command fails.
+     * @throws ComposerInstallException If the Composer require command fails.
      */
     function composer_require(string ...$packages): void
     {
-        sort($packages);
-
-        $key = hash('sha256', implode(' ', $packages));
-        $sandboxDir = cpx_path(".exec_cache/{$key}");
-
-        $sandbox = Metadata::open()->execCache[$key] ?? new ExecSandboxMetadata(key: $key);
-
-        if (! is_dir($sandboxDir)) {
-            mkdir($sandboxDir, 0755, true);
-
-            file_put_contents($sandboxDir.'/composer.json', json_encode([
-                'require' => new stdClass,
-                'config' => [
-                    'vendor-dir' => './vendor',
-                ],
-            ], JSON_PRETTY_PRINT));
-
-            foreach ($packages as $package) {
-                try {
-                    ComposerRunner::run(['require', $package], $sandboxDir);
-                    $sandbox->lastUpdatedAt = time();
-                } catch (Exception) {
-                    throw new ComposerInstallException("Failed to install package: {$package}.");
-                }
-            }
-        } elseif ($sandbox->lastUpdatedAt !== null && time() - $sandbox->lastUpdatedAt >= Metadata::UPDATE_CHECK_INTERVAL) {
-            try {
-                ComposerRunner::run(['update'], $sandboxDir);
-                $sandbox->lastUpdatedAt = time();
-            } catch (Exception) {
-                // Update failed, keep using the existing sandbox.
-            }
-        }
-
-        $sandbox->packages = $packages;
-        $sandbox->lastRunAt = time();
-
-        Metadata::transaction(function (Metadata $metadata) use ($key, $sandbox): void {
-            $metadata->execCache[$key] = $sandbox;
-        });
-
-        $autoloadFile = "{$sandboxDir}/vendor/autoload.php";
-
-        if (! file_exists($autoloadFile)) {
-            throw new Exception("Autoload file not found in {$sandboxDir}/vendor/. Composer installation may have failed.");
-        }
-
-        if (isset(PhpExecutionHelper::$classAliasAutoloader)) {
-            PhpExecutionHelper::$classAliasAutoloader->addAliases($sandboxDir);
-        }
-
-        require_once $autoloadFile;
+        ExecSandbox::forPackages($packages)->load();
     }
 }
 

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -38,7 +38,6 @@ test('the all option removes every tracked package and exec cache directory', fu
         ->and(is_dir($execDirectory))->toBeFalse()
         ->and(json_decode((string) file_get_contents(cpx_path('.cpx_metadata.json')), true))->toBe([
             'version' => 2,
-            'aliases' => [],
             'packages' => [],
             'execCache' => [],
         ]);

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -43,6 +43,27 @@ test('the all option removes every tracked package and exec cache directory', fu
         ]);
 });
 
+test('cleaning a package prunes the now-empty vendor directories', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(cpx_path('laravel/pint/latest'), 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => '2024-01-01 00:00:00',
+                'last_run' => '2024-01-01 00:00:00',
+            ],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    runCpxCommand(['clean', '--all']);
+
+    expect(is_dir(cpx_path('laravel/pint/latest')))->toBeFalse()
+        ->and(is_dir(cpx_path('laravel/pint')))->toBeFalse()
+        ->and(is_dir(cpx_path('laravel')))->toBeFalse();
+});
+
 test('the sandbox option removes exec caches but preserves package caches', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cpx\Application;
+use Cpx\Cache\Metadata;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -37,6 +38,8 @@ test('it removes all tracked package and exec cache directories', function () {
     expect(is_dir($packageDirectory))->toBeFalse()
         ->and(is_dir($execDirectory))->toBeFalse()
         ->and(json_decode((string) file_get_contents(cpx_path('.cpx_metadata.json')), true))->toBe([
+            'version' => 2,
+            'aliases' => [],
             'packages' => [],
             'execCache' => [],
         ]);
@@ -47,11 +50,9 @@ test('it preserves fresh tracked package cache directories', function () {
 
     $packageDirectory = cpx_path('laravel/pint/latest');
 
-    mkdir($packageDirectory, 0755, true);
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
 
-    if (! is_dir(dirname(cpx_path('.cpx_metadata.json')))) {
-        mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
-    }
     file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
         'packages' => [
             'laravel/pint' => [
@@ -67,10 +68,79 @@ test('it preserves fresh tracked package cache directories', function () {
     expect(is_dir($packageDirectory))->toBeTrue();
 });
 
-test('orphaned package directories are detected and cleaned')->todo(
-    'Enable when cleanup scans for cache directories missing from metadata.',
-);
+test('orphaned package directories are detected and cleaned', function () {
+    $this->useIsolatedComposerHome();
 
-test('cleanup refuses to delete paths outside the cpx cache root')->todo(
-    'Enable when cleanup validates every deletion stays inside the cpx cache root.',
-);
+    $orphan = cpx_path('orphan/package/latest');
+    mkdir($orphan.'/vendor', 0755, true);
+    file_put_contents($orphan.'/vendor/autoload.php', '<?php');
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status, $output] = runCpxCommand(['clean']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($orphan))->toBeFalse()
+        ->and($output)->toContain('orphan/package/latest');
+});
+
+test('incomplete install directories are treated as orphaned and removed', function () {
+    $this->useIsolatedComposerHome();
+
+    $incomplete = cpx_path('laravel/pint/latest');
+    mkdir($incomplete.'/vendor', 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => date('Y-m-d H:i:s'),
+                'last_run' => date('Y-m-d H:i:s'),
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir($incomplete))->toBeFalse()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
+});
+
+test('orphaned exec sandboxes are removed while tracked fresh sandboxes are preserved', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(cpx_path('.exec_cache/orphan-key'), 0755, true);
+    mkdir(cpx_path('.exec_cache/tracked-key'), 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [],
+        'execCache' => [
+            'tracked-key' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir(cpx_path('.exec_cache/orphan-key')))->toBeFalse()
+        ->and(is_dir(cpx_path('.exec_cache/tracked-key')))->toBeTrue();
+});
+
+test('cleanup refuses to delete paths outside the cpx cache root', function () {
+    $this->useIsolatedComposerHome();
+
+    $outside = $this->temporaryDirectory('cpx-outside');
+    file_put_contents($outside.'/keep.txt', 'x');
+
+    mkdir(cpx_path('.exec_cache'), 0755, true);
+    symlink($outside, cpx_path('.exec_cache/escape'));
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($outside))->toBeTrue()
+        ->and(file_exists($outside.'/keep.txt'))->toBeTrue();
+});

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -323,7 +323,7 @@ test('cleanup refuses to delete paths outside the cpx cache root', function () {
 
     [$status] = runCpxCommand(['clean']);
 
-    expect($status)->toBe(0)
+    expect($status)->toBe(1)
         ->and(is_dir($outside))->toBeTrue()
         ->and(file_exists($outside.'/keep.txt'))->toBeTrue()
         ->and(promptOutput())->toContain('Could not remove');

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -68,6 +68,54 @@ test('it preserves fresh tracked package cache directories', function () {
     expect(is_dir($packageDirectory))->toBeTrue();
 });
 
+test('it preserves a freshly installed package that was never run', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => date('Y-m-d H:i:s'),
+                'last_run' => null,
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir($packageDirectory))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeTrue();
+});
+
+test('it reclaims a package that was installed long ago and never run', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => '2024-01-01 00:00:00',
+                'last_run' => null,
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir($packageDirectory))->toBeFalse()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
+});
+
 test('orphaned package directories are detected and cleaned', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -1,11 +1,13 @@
 <?php
 
-use Cpx\Application;
 use Cpx\Cache\Metadata;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\BufferedOutput;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-test('it removes all tracked package and exec cache directories', function () {
+uses(MockeryPHPUnitIntegration::class);
+
+test('the all option removes every tracked package and exec cache directory', function () {
     $this->useIsolatedComposerHome();
 
     $packageDirectory = cpx_path('laravel/pint/latest');
@@ -14,9 +16,6 @@ test('it removes all tracked package and exec cache directories', function () {
     mkdir($packageDirectory, 0755, true);
     mkdir($execDirectory, 0755, true);
 
-    if (! is_dir(dirname(cpx_path('.cpx_metadata.json')))) {
-        mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
-    }
     file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
         'packages' => [
             'laravel/pint' => [
@@ -33,7 +32,7 @@ test('it removes all tracked package and exec cache directories', function () {
         ],
     ], JSON_THROW_ON_ERROR));
 
-    (new Application)->run(new ArgvInput(['cpx', 'clean', '--all']), new BufferedOutput);
+    runCpxCommand(['clean', '--all']);
 
     expect(is_dir($packageDirectory))->toBeFalse()
         ->and(is_dir($execDirectory))->toBeFalse()
@@ -45,7 +44,143 @@ test('it removes all tracked package and exec cache directories', function () {
         ]);
 });
 
-test('it preserves fresh tracked package cache directories', function () {
+test('the sandbox option removes exec caches but preserves package caches', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    $sandboxDirectory = cpx_path('.exec_cache/sandbox');
+    mkdir($sandboxDirectory, 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => date('Y-m-d H:i:s'),
+                'last_run' => date('Y-m-d H:i:s'),
+            ],
+        ],
+        'execCache' => [
+            'sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--sandbox']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($packageDirectory))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeTrue()
+        ->and(is_dir($sandboxDirectory))->toBeFalse()
+        ->and(Metadata::open()->execCache)->toBe([]);
+});
+
+test('the sandbox option is a no-op when there are no sandboxes', function () {
+    $this->useIsolatedComposerHome();
+
+    [$status] = runCpxCommand(['clean', '--sandbox']);
+
+    expect($status)->toBe(0)
+        ->and(promptOutput())->toContain('Nothing to clean');
+});
+
+test('a days window of zero reclaims everything older than now', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => '2024-01-01 00:00:00',
+                'last_run' => '2024-01-01 00:00:00',
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--days=0']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($packageDirectory))->toBeFalse()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
+});
+
+test('a long days window preserves recently active packages', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => date('Y-m-d H:i:s'),
+                'last_run' => date('Y-m-d H:i:s'),
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--days=3650']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($packageDirectory))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeTrue();
+});
+
+test('an invalid days value is rejected before any cleanup runs', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => '2024-01-01 00:00:00',
+                'last_run' => null,
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--days=abc']);
+
+    expect($status)->not->toBe(0)
+        ->and(promptOutput())->toContain('positive integer')
+        ->and(is_dir($packageDirectory))->toBeTrue();
+});
+
+test('a negative days value is rejected before any cleanup runs', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => [
+                'last_updated' => '2024-01-01 00:00:00',
+                'last_run' => null,
+            ],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--days=-5']);
+
+    expect($status)->not->toBe(0)
+        ->and(promptOutput())->toContain('positive integer')
+        ->and(is_dir($packageDirectory))->toBeTrue();
+});
+
+test('a bare clean preserves fresh tracked package cache directories', function () {
     $this->useIsolatedComposerHome();
 
     $packageDirectory = cpx_path('laravel/pint/latest');
@@ -63,12 +198,12 @@ test('it preserves fresh tracked package cache directories', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    (new Application)->run(new ArgvInput(['cpx', 'clean']), new BufferedOutput);
+    runCpxCommand(['clean']);
 
     expect(is_dir($packageDirectory))->toBeTrue();
 });
 
-test('it preserves a freshly installed package that was never run', function () {
+test('a bare clean preserves a freshly installed package that was never run', function () {
     $this->useIsolatedComposerHome();
 
     $packageDirectory = cpx_path('laravel/pint/latest');
@@ -92,7 +227,7 @@ test('it preserves a freshly installed package that was never run', function () 
         ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeTrue();
 });
 
-test('it reclaims a package that was installed long ago and never run', function () {
+test('a bare clean reclaims a package that was installed long ago and never run', function () {
     $this->useIsolatedComposerHome();
 
     $packageDirectory = cpx_path('laravel/pint/latest');
@@ -127,11 +262,11 @@ test('orphaned package directories are detected and cleaned', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    [$status, $output] = runCpxCommand(['clean']);
+    [$status] = runCpxCommand(['clean']);
 
     expect($status)->toBe(0)
         ->and(is_dir($orphan))->toBeFalse()
-        ->and($output)->toContain('orphan/package/latest');
+        ->and(promptOutput())->toContain('orphan/package/latest');
 });
 
 test('incomplete install directories are treated as orphaned and removed', function () {
@@ -190,5 +325,156 @@ test('cleanup refuses to delete paths outside the cpx cache root', function () {
 
     expect($status)->toBe(0)
         ->and(is_dir($outside))->toBeTrue()
-        ->and(file_exists($outside.'/keep.txt'))->toBeTrue();
+        ->and(file_exists($outside.'/keep.txt'))->toBeTrue()
+        ->and(promptOutput())->toContain('Could not remove');
+});
+
+test('the summary lists the caches that were removed', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => '2024-01-01 00:00:00', 'last_run' => '2024-01-01 00:00:00'],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean']);
+
+    expect($status)->toBe(0)
+        ->and(promptOutput())
+        ->toContain('Clean Summary')
+        ->toContain('Removed')
+        ->toContain('laravel/pint');
+});
+
+test('the interactive prompt shows the available clean options', function () {
+    $this->useIsolatedComposerHome();
+
+    Prompt::fake([Key::ENTER, Key::ENTER]);
+
+    runCpxCommand(['clean']);
+
+    expect(promptOutput())
+        ->toContain('What would you like to clean?')
+        ->toContain('All cached packages and sandboxes')
+        ->toContain('Only sandbox (exec) caches')
+        ->toContain('Packages older than a number of days');
+});
+
+test('choosing "all" interactively cleans every package and sandbox', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    $execDirectory = cpx_path('.exec_cache/sandbox');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+    mkdir($execDirectory, 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => date('Y-m-d H:i:s'), 'last_run' => date('Y-m-d H:i:s')],
+        ],
+        'execCache' => [
+            'sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    // From the "period" default, move up twice to "all", then confirm.
+    Prompt::fake([Key::UP, Key::UP, Key::ENTER]);
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir($packageDirectory))->toBeFalse()
+        ->and(is_dir($execDirectory))->toBeFalse()
+        ->and(Metadata::open()->packages)->toBe([])
+        ->and(Metadata::open()->execCache)->toBe([]);
+});
+
+test('choosing "sandbox" interactively preserves package caches', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    $sandboxDirectory = cpx_path('.exec_cache/sandbox');
+    mkdir($sandboxDirectory, 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => date('Y-m-d H:i:s'), 'last_run' => date('Y-m-d H:i:s')],
+        ],
+        'execCache' => [
+            'sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    // From the "period" default, move up once to "sandbox", then confirm.
+    Prompt::fake([Key::UP, Key::ENTER]);
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir($packageDirectory))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeTrue()
+        ->and(is_dir($sandboxDirectory))->toBeFalse()
+        ->and(Metadata::open()->execCache)->toBe([]);
+});
+
+test('choosing "period" interactively cleans by the entered number of days', function () {
+    $this->useIsolatedComposerHome();
+
+    $idle = cpx_path('laravel/pint/latest');
+    mkdir($idle.'/vendor', 0755, true);
+    file_put_contents($idle.'/vendor/autoload.php', '<?php');
+
+    $recent = cpx_path('phpunit/phpunit/latest');
+    mkdir($recent.'/vendor', 0755, true);
+    file_put_contents($recent.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => date('Y-m-d H:i:s', time() - 10 * 86400), 'last_run' => date('Y-m-d H:i:s', time() - 10 * 86400)],
+            'phpunit/phpunit' => ['last_updated' => date('Y-m-d H:i:s', time() - 3 * 86400), 'last_run' => date('Y-m-d H:i:s', time() - 3 * 86400)],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    // Confirm the "period" default, clear the prefilled "30", then enter "7".
+    Prompt::fake([Key::ENTER, Key::BACKSPACE, Key::BACKSPACE, '7', Key::ENTER]);
+
+    runCpxCommand(['clean']);
+
+    expect(is_dir($idle))->toBeFalse()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse()
+        ->and(is_dir($recent))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('phpunit/phpunit'))->toBeTrue();
+});
+
+test('the interactive number prompt rejects values below one and re-prompts', function () {
+    $this->useIsolatedComposerHome();
+
+    $idle = cpx_path('laravel/pint/latest');
+    mkdir($idle.'/vendor', 0755, true);
+    file_put_contents($idle.'/vendor/autoload.php', '<?php');
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => date('Y-m-d H:i:s', time() - 10 * 86400), 'last_run' => date('Y-m-d H:i:s', time() - 10 * 86400)],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    // Confirm "period", clear "30", submit invalid "0" (rejected), then enter "5".
+    Prompt::fake([Key::ENTER, Key::BACKSPACE, Key::BACKSPACE, '0', Key::ENTER, Key::BACKSPACE, '5', Key::ENTER]);
+
+    runCpxCommand(['clean']);
+
+    expect(promptOutput())->toContain('Must be at least 1')
+        ->and(is_dir($idle))->toBeFalse()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
 });

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -74,10 +74,10 @@ test('aliases lists aliased package commands', function () {
 test('clean reports when there are no packages to clean', function () {
     $this->useIsolatedComposerHome();
 
-    [$status, $output] = runCpxCommand(['clean']);
+    [$status] = runCpxCommand(['clean']);
 
     expect($status)->toBe(0)
-        ->and($output)->toContain('There were no packages to clean.');
+        ->and(promptOutput())->toContain('Nothing to clean');
 });
 
 test('update reports when there are no packages to update', function () {

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -44,6 +44,25 @@ test('list shows when no packages are installed', function () {
         ->and($output)->not->toContain('Available commands');
 });
 
+test('list renders installed packages with their last run timestamp', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => '2024-01-02 03:04:05', 'last_run' => '2024-01-02 03:04:05'],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status, $output] = runCpxCommand(['list']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Installed Packages:')
+        ->and($output)->toContain('laravel/pint')
+        ->and($output)->toContain('Last Run: 2024-01-02 03:04:05');
+});
+
 test('aliases lists aliased package commands', function () {
     [$status, $output] = runCpxCommand(['aliases']);
 
@@ -115,6 +134,7 @@ test('tinker runs the cached psysh package with the bundled config', function ()
     $packageDirectory = cpx_path('psy/psysh/latest/vendor/psy/psysh');
     mkdir($packageDirectory, 0755, true);
 
+    file_put_contents(cpx_path('psy/psysh/latest/vendor/autoload.php'), '<?php');
     file_put_contents($packageDirectory.'/composer.json', json_encode([
         'bin' => ['psysh'],
     ], JSON_THROW_ON_ERROR));

--- a/tests/Feature/ComposerRequireTest.php
+++ b/tests/Feature/ComposerRequireTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Cpx\Cache\ExecSandboxMetadata;
+use Cpx\Cache\Metadata;
+
+test('composer_require installs into a safe sandbox key and records a typed exec entry', function () {
+    $this->useIsolatedComposerHome();
+
+    $binDirectory = $this->temporaryDirectory('cpx-bin');
+    writeExecutable($binDirectory.'/composer', composerAutoloaderStub());
+    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+
+    composer_require('laravel/pint');
+
+    $key = hash('sha256', 'laravel/pint');
+    $sandbox = Metadata::open()->execCache[$key];
+
+    expect(is_dir(cpx_path(".exec_cache/{$key}")))->toBeTrue()
+        ->and($sandbox)->toBeInstanceOf(ExecSandboxMetadata::class)
+        ->and($sandbox->key)->toBe($key)
+        ->and($sandbox->packages)->toBe(['laravel/pint'])
+        ->and($sandbox->lastRunAt)->not->toBeNull()
+        ->and(file_exists(cpx_path(".exec_cache/{$key}/vendor/autoload.php")))->toBeTrue();
+});

--- a/tests/Feature/PartialInstallTest.php
+++ b/tests/Feature/PartialInstallTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Cpx\Cache\Metadata;
+use Cpx\Packages\Package;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+test('a failed install leaves no final dir, no staging residue, and records nothing', function () {
+    $this->useIsolatedComposerHome();
+
+    $binDirectory = $this->temporaryDirectory('cpx-bin');
+    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php exit(1);\n");
+    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+
+    $package = Package::parse('laravel/pint');
+
+    expect(fn () => $package->installOrUpdatePackage(new BufferedOutput))->toThrow(Exception::class);
+
+    expect(is_dir($package->installPath()))->toBeFalse()
+        ->and(glob(cpx_path('laravel/pint/*.installing.*')) ?: [])->toBe([])
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
+});
+
+test('a successful install atomically populates the final dir and records last_updated', function () {
+    $this->useIsolatedComposerHome();
+
+    $binDirectory = $this->temporaryDirectory('cpx-bin');
+    writeExecutable($binDirectory.'/composer', composerAutoloaderStub());
+    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+
+    $package = Package::parse('laravel/pint');
+    $package->installOrUpdatePackage(new BufferedOutput);
+
+    expect(file_exists($package->installPath().'/vendor/autoload.php'))->toBeTrue()
+        ->and(glob(cpx_path('laravel/pint/*.installing.*')) ?: [])->toBe([])
+        ->and(Metadata::open()->packages['laravel/pint']->lastUpdatedAt)->not->toBeNull();
+});
+
+test('an install dir missing the autoloader is treated as incomplete and re-staged', function () {
+    $this->useIsolatedComposerHome();
+
+    $package = Package::parse('laravel/pint');
+
+    // Fresh metadata would let a naive "already installed" check skip the broken dir.
+    Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate($package));
+    mkdir($package->installPath().'/vendor', 0755, true);
+
+    $binDirectory = $this->temporaryDirectory('cpx-bin');
+    writeExecutable($binDirectory.'/composer', composerAutoloaderStub());
+    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+
+    $package->installOrUpdatePackage(new BufferedOutput);
+
+    expect(file_exists($package->installPath().'/vendor/autoload.php'))->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,11 +1,17 @@
 <?php
 
 use Cpx\Application;
+use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature', 'Unit');
+
+function promptOutput(): string
+{
+    return Prompt::strippedContent();
+}
 
 /**
  * @param  list<string>  $arguments

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -27,6 +27,18 @@ function writeExecutable(string $path, string $contents): void
 }
 
 /**
+ * A fake `composer` that writes a working autoloader into the install directory it is given.
+ */
+function composerAutoloaderStub(): string
+{
+    return "#!/usr/bin/env php\n<?php\n"
+        ."\$dir = null;\n"
+        ."foreach (\$argv as \$arg) { if (strncmp(\$arg, '--working-dir=', 14) === 0) { \$dir = substr(\$arg, 14); } }\n"
+        ."if (\$dir !== null) { @mkdir(\$dir.'/vendor', 0755, true); file_put_contents(\$dir.'/vendor/autoload.php', '<?php'); }\n"
+        .'exit(0);'."\n";
+}
+
+/**
  * @param  list<string>  $bins
  * @param  array<string, string>  $executables
  */
@@ -37,6 +49,7 @@ function prepareCachedPackage(string $package, array $bins, array $executables =
 
     mkdir($packageDirectory, 0755, true);
     file_put_contents($packageDirectory.'/composer.json', json_encode(['bin' => $bins], JSON_THROW_ON_ERROR));
+    file_put_contents(cpx_path("{$vendor}/{$name}/latest/vendor/autoload.php"), '<?php');
 
     foreach ($executables as $bin => $contents) {
         writeExecutable("{$packageDirectory}/{$bin}", $contents);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,13 @@
 
 namespace Tests;
 
+use Laravel\Prompts\Output\BufferedConsoleOutput;
+use Laravel\Prompts\Prompt;
+use Laravel\Prompts\Terminal;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use ReflectionProperty;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -18,6 +22,16 @@ abstract class TestCase extends BaseTestCase
     private array $temporaryDirectories = [];
 
     private ?string $workingDirectory = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Prompt::interactive(false);
+        Prompt::setOutput(new BufferedConsoleOutput);
+
+        (new ReflectionProperty(Prompt::class, 'terminal'))->setValue(null, new Terminal);
+    }
 
     protected function tearDown(): void
     {

--- a/tests/Unit/ExecSandboxMetadataTest.php
+++ b/tests/Unit/ExecSandboxMetadataTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Cpx\Cache\ExecSandboxMetadata;
+use Cpx\Cache\Metadata;
+
+test('it round-trips a typed exec sandbox record with packages and timestamps', function () {
+    $this->useIsolatedComposerHome();
+
+    Metadata::transaction(function (Metadata $metadata) {
+        $metadata->execCache['abc123'] = new ExecSandboxMetadata(
+            key: 'abc123',
+            packages: ['laravel/pint', 'phpstan/phpstan'],
+            lastUpdatedAt: 111,
+            lastRunAt: 222,
+        );
+    });
+
+    $sandbox = Metadata::open()->execCache['abc123'];
+
+    expect($sandbox)->toBeInstanceOf(ExecSandboxMetadata::class)
+        ->and($sandbox->key)->toBe('abc123')
+        ->and($sandbox->packages)->toBe(['laravel/pint', 'phpstan/phpstan'])
+        ->and($sandbox->lastUpdatedAt)->toBe(111)
+        ->and($sandbox->lastRunAt)->toBe(222);
+});

--- a/tests/Unit/FilesystemTest.php
+++ b/tests/Unit/FilesystemTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Cpx\Support\Filesystem;
+
+test('writeAtomic writes the full contents and leaves no temp residue', function () {
+    $directory = $this->temporaryDirectory('cpx-fs');
+    $path = "{$directory}/data.json";
+
+    Filesystem::writeAtomic($path, '{"hello":"world"}');
+
+    expect(file_get_contents($path))->toBe('{"hello":"world"}')
+        ->and(glob("{$directory}/*.tmp"))->toBe([]);
+});
+
+test('writeAtomic overwrites an existing file without truncation residue', function () {
+    $directory = $this->temporaryDirectory('cpx-fs');
+    $path = "{$directory}/data.json";
+
+    file_put_contents($path, 'previous contents that are noticeably longer');
+    Filesystem::writeAtomic($path, 'new');
+
+    expect(file_get_contents($path))->toBe('new')
+        ->and(glob("{$directory}/*.tmp"))->toBe([]);
+});
+
+test('deleteDirectoryWithin removes a directory genuinely inside the root', function () {
+    $root = $this->temporaryDirectory('cpx-root');
+    $target = "{$root}/laravel/pint/latest";
+
+    mkdir($target, 0755, true);
+    file_put_contents("{$target}/composer.json", '{}');
+
+    Filesystem::deleteDirectoryWithin($target, $root);
+
+    expect(is_dir($target))->toBeFalse();
+});
+
+test('deleteDirectoryWithin refuses to delete a path resolving outside the root', function () {
+    $base = $this->temporaryDirectory('cpx-base');
+    $root = "{$base}/root";
+    $escape = "{$base}/escape";
+
+    mkdir($root, 0755, true);
+    mkdir($escape, 0755, true);
+    file_put_contents("{$escape}/keep.txt", 'x');
+
+    expect(fn () => Filesystem::deleteDirectoryWithin("{$root}/../escape", $root))
+        ->toThrow(RuntimeException::class);
+
+    expect(is_dir($escape))->toBeTrue()
+        ->and(file_exists("{$escape}/keep.txt"))->toBeTrue();
+});
+
+test('deleteDirectoryWithin refuses to follow a symlink escaping the root', function () {
+    $base = $this->temporaryDirectory('cpx-symlink');
+    $root = "{$base}/root";
+    $outside = "{$base}/outside";
+
+    mkdir($root, 0755, true);
+    mkdir($outside, 0755, true);
+    file_put_contents("{$outside}/keep.txt", 'x');
+    symlink($outside, "{$root}/link");
+
+    expect(fn () => Filesystem::deleteDirectoryWithin("{$root}/link", $root))
+        ->toThrow(RuntimeException::class);
+
+    expect(is_dir($outside))->toBeTrue()
+        ->and(file_exists("{$outside}/keep.txt"))->toBeTrue();
+});

--- a/tests/Unit/FilesystemTest.php
+++ b/tests/Unit/FilesystemTest.php
@@ -67,3 +67,60 @@ test('deleteDirectoryWithin refuses to follow a symlink escaping the root', func
     expect(is_dir($outside))->toBeTrue()
         ->and(file_exists("{$outside}/keep.txt"))->toBeTrue();
 });
+
+test('pruneEmptyParents removes empty parent directories up to the root', function () {
+    $root = $this->temporaryDirectory('cpx-prune');
+    $leaf = "{$root}/laravel/pint/latest";
+
+    mkdir($leaf, 0755, true);
+    Filesystem::deleteDirectory($leaf);
+
+    Filesystem::pruneEmptyParents($leaf, $root);
+
+    expect(is_dir("{$root}/laravel/pint"))->toBeFalse()
+        ->and(is_dir("{$root}/laravel"))->toBeFalse()
+        ->and(is_dir($root))->toBeTrue();
+});
+
+test('pruneEmptyParents keeps a parent that still holds another version', function () {
+    $root = $this->temporaryDirectory('cpx-prune');
+    $removed = "{$root}/laravel/pint/latest";
+    $sibling = "{$root}/laravel/pint/3.0";
+
+    mkdir($removed, 0755, true);
+    mkdir($sibling, 0755, true);
+    Filesystem::deleteDirectory($removed);
+
+    Filesystem::pruneEmptyParents($removed, $root);
+
+    expect(is_dir($sibling))->toBeTrue()
+        ->and(is_dir("{$root}/laravel/pint"))->toBeTrue()
+        ->and(is_dir("{$root}/laravel"))->toBeTrue();
+});
+
+test('pruneEmptyParents never removes the cache root', function () {
+    $root = $this->temporaryDirectory('cpx-prune');
+    $leaf = "{$root}/vendor/name";
+
+    mkdir($leaf, 0755, true);
+    Filesystem::deleteDirectory($leaf);
+
+    Filesystem::pruneEmptyParents($leaf, $root);
+
+    expect(is_dir("{$root}/vendor"))->toBeFalse()
+        ->and(is_dir($root))->toBeTrue();
+});
+
+test('pruneEmptyParents leaves directories outside the root untouched', function () {
+    $base = $this->temporaryDirectory('cpx-prune');
+    $root = "{$base}/root";
+    $outside = "{$base}/outside/child";
+
+    mkdir($root, 0755, true);
+    mkdir($outside, 0755, true);
+    Filesystem::deleteDirectory($outside);
+
+    Filesystem::pruneEmptyParents($outside, $root);
+
+    expect(is_dir("{$base}/outside"))->toBeTrue();
+});

--- a/tests/Unit/LockTest.php
+++ b/tests/Unit/LockTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Cpx\Support\Lock;
+
+test('it runs a critical section and returns its result', function () {
+    $lockFile = $this->temporaryDirectory('cpx-lock').'/cpx.lock';
+
+    $result = Lock::run($lockFile, fn () => 'done');
+
+    expect($result)->toBe('done');
+});
+
+test('it releases the lock so a later acquisition succeeds', function () {
+    $lockFile = $this->temporaryDirectory('cpx-lock').'/cpx.lock';
+
+    $first = Lock::run($lockFile, fn () => 'first');
+    $second = Lock::run($lockFile, fn () => 'second');
+
+    expect($first)->toBe('first')
+        ->and($second)->toBe('second');
+});

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -54,7 +54,7 @@ test('a transaction persists and round-trips package timestamps', function () {
         ->and($metadata->packages['laravel/pint']->lastRunAt)->not->toBeNull();
 });
 
-test('it writes the schema version, round-trips an empty aliases section, and exposes the install path', function () {
+test('it writes the schema version and exposes the install path', function () {
     $this->useIsolatedComposerHome();
 
     Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate(Package::parse('laravel/pint')));
@@ -63,12 +63,10 @@ test('it writes the schema version, round-trips an empty aliases section, and ex
     $metadata = Metadata::open();
 
     expect($decoded['version'])->toBe(2)
-        ->and($decoded['aliases'])->toBe([])
-        ->and($metadata->aliases)->toBe([])
         ->and($metadata->packages['laravel/pint']->installPath())->toBe(cpx_path('laravel/pint/latest'));
 });
 
-test('it loads a legacy metadata file without a version or aliases section', function () {
+test('it loads a legacy metadata file without a version section', function () {
     $this->useIsolatedComposerHome();
 
     mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
@@ -85,8 +83,7 @@ test('it loads a legacy metadata file without a version or aliases section', fun
 
     expect($metadata->packages['laravel/pint']->lastUpdatedAt)->toBe(strtotime('2024-01-01 00:00:00'))
         ->and($metadata->execCache['sandbox'])->toBeInstanceOf(ExecSandboxMetadata::class)
-        ->and($metadata->execCache['sandbox']->lastRunAt)->toBe(1)
-        ->and($metadata->aliases)->toBe([]);
+        ->and($metadata->execCache['sandbox']->lastRunAt)->toBe(1);
 });
 
 test('interleaved transactions keep every update and leave valid json', function () {

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -16,10 +16,9 @@ test('it opens an empty metadata state when no metadata file exists', function (
 test('it saves readable metadata json and round trips package timestamps', function () {
     $this->useIsolatedComposerHome();
 
-    Metadata::open()
+    Metadata::transaction(fn (Metadata $metadata) => $metadata
         ->recordUpdate(Package::parse('laravel/pint'))
-        ->recordRun(Package::parse('laravel/pint'))
-        ->save();
+        ->recordRun(Package::parse('laravel/pint')));
 
     $metadataFile = cpx_path('.cpx_metadata.json');
     $contents = file_get_contents($metadataFile);
@@ -84,7 +83,7 @@ test('it loads a legacy metadata file without a version or aliases section', fun
 
     $metadata = Metadata::open();
 
-    expect($metadata->packages['laravel/pint']->lastUpdatedAt)->toBe('2024-01-01 00:00:00')
+    expect($metadata->packages['laravel/pint']->lastUpdatedAt)->toBe(strtotime('2024-01-01 00:00:00'))
         ->and($metadata->execCache['sandbox'])->toBeInstanceOf(ExecSandboxMetadata::class)
         ->and($metadata->execCache['sandbox']->lastRunAt)->toBe(1)
         ->and($metadata->aliases)->toBe([]);

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cpx\Cache\ExecSandboxMetadata;
 use Cpx\Cache\Metadata;
 use Cpx\Packages\Package;
 
@@ -41,4 +42,66 @@ test('it handles invalid metadata json as an empty state', function () {
 
     expect($metadata->packages)->toBe([])
         ->and($metadata->execCache)->toBe([]);
+});
+
+test('a transaction persists and round-trips package timestamps', function () {
+    $this->useIsolatedComposerHome();
+
+    Metadata::transaction(fn (Metadata $metadata) => $metadata->recordRun(Package::parse('laravel/pint')));
+
+    $metadata = Metadata::open();
+
+    expect($metadata->hasPackage('laravel/pint'))->toBeTrue()
+        ->and($metadata->packages['laravel/pint']->lastRunAt)->not->toBeNull();
+});
+
+test('it writes the schema version, round-trips an empty aliases section, and exposes the install path', function () {
+    $this->useIsolatedComposerHome();
+
+    Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate(Package::parse('laravel/pint')));
+
+    $decoded = json_decode((string) file_get_contents(cpx_path('.cpx_metadata.json')), true);
+    $metadata = Metadata::open();
+
+    expect($decoded['version'])->toBe(2)
+        ->and($decoded['aliases'])->toBe([])
+        ->and($metadata->aliases)->toBe([])
+        ->and($metadata->packages['laravel/pint']->installPath())->toBe(cpx_path('laravel/pint/latest'));
+});
+
+test('it loads a legacy metadata file without a version or aliases section', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => '2024-01-01 00:00:00', 'last_run' => '2024-01-01 00:00:00'],
+        ],
+        'execCache' => [
+            'sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => 1, 'last_run' => 1],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    $metadata = Metadata::open();
+
+    expect($metadata->packages['laravel/pint']->lastUpdatedAt)->toBe('2024-01-01 00:00:00')
+        ->and($metadata->execCache['sandbox'])->toBeInstanceOf(ExecSandboxMetadata::class)
+        ->and($metadata->execCache['sandbox']->lastRunAt)->toBe(1)
+        ->and($metadata->aliases)->toBe([]);
+});
+
+test('interleaved transactions keep every update and leave valid json', function () {
+    $this->useIsolatedComposerHome();
+
+    Metadata::transaction(fn (Metadata $metadata) => $metadata->recordRun(Package::parse('laravel/pint')));
+    Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate(Package::parse('phpstan/phpstan')));
+
+    $decoded = json_decode((string) file_get_contents(cpx_path('.cpx_metadata.json')), true);
+    $metadata = Metadata::open();
+
+    expect($decoded)->toBeArray()
+        ->and($metadata->hasPackage('laravel/pint'))->toBeTrue()
+        ->and($metadata->hasPackage('phpstan/phpstan'))->toBeTrue()
+        ->and($metadata->packages['laravel/pint']->lastRunAt)->not->toBeNull()
+        ->and($metadata->packages['phpstan/phpstan']->lastUpdatedAt)->not->toBeNull();
 });

--- a/tests/Unit/PackageMetadataTest.php
+++ b/tests/Unit/PackageMetadataTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Cpx\Cache\PackageMetadata;
+use Cpx\Packages\Package;
+use Cpx\Packages\PackageAliases;
+
+test('a package alias is resolved from the registry, never stored on the record', function () {
+    expect(property_exists(PackageMetadata::class, 'alias'))->toBeFalse();
+
+    $aliasForPint = null;
+
+    foreach (PackageAliases::all() as $alias => $definition) {
+        if ($definition->package === 'laravel/pint') {
+            $aliasForPint = $alias;
+
+            break;
+        }
+    }
+
+    expect($aliasForPint)->toBe('pint');
+});
+
+test('lastRunForDisplay falls back to N/A when a package has never run', function () {
+    $record = new PackageMetadata(Package::parse('laravel/pint'));
+
+    expect($record->lastRunForDisplay())->toBe('N/A');
+});

--- a/tests/Unit/PackageTest.php
+++ b/tests/Unit/PackageTest.php
@@ -54,6 +54,41 @@ test('it rejects invalid package targets', function (string $target) {
     'laravel/pint:..',
 ])->throws(InvalidArgumentException::class);
 
-test('package cache keys are derived from validated identifiers or stable safe hashes')->todo(
-    'Enable when cache keys are redesigned to avoid raw constraint punctuation.',
-);
+test('it derives filesystem-safe version segments from hostile constraints', function (string $target) {
+    $segment = Package::parse($target)->versionName();
+
+    expect($segment)->not->toBe('')
+        ->and(preg_match('#[/\\\\:*?"<>|\s]#', $segment))->toBe(0);
+})->with([
+    'laravel/pint:^1@dev',
+    'laravel/pint:~1.0',
+    'laravel/pint:>=2,<3',
+    'laravel/pint:dev-main',
+    'laravel/pint:*',
+    'laravel/pint:1.0.0|2.0.0',
+]);
+
+test('it maps an unversioned package to the literal latest segment', function () {
+    expect(Package::parse('laravel/pint')->versionName())->toBe('latest');
+});
+
+test('it derives a deterministic version segment for the same constraint', function () {
+    $first = Package::parse('laravel/pint:^1@dev')->versionName();
+    $second = Package::parse('laravel/pint:^1@dev')->versionName();
+
+    expect($first)->toBe($second);
+});
+
+test('it disambiguates constraints that slug to the same readable prefix', function () {
+    $caret = Package::parse('laravel/pint:^1')->versionName();
+    $tilde = Package::parse('laravel/pint:~1')->versionName();
+
+    expect($caret)->not->toBe($tilde);
+});
+
+test('it keeps the true package string while using a safe directory key', function () {
+    $package = Package::parse('laravel/pint:>=2,<3');
+
+    expect($package->fullPackageString())->toBe('laravel/pint:>=2,<3')
+        ->and(preg_match('#[/\\\\:*?"<>|,\s]#', $package->versionName()))->toBe(0);
+});


### PR DESCRIPTION
cpx keeps a shared metadata file next to its package and exec-sandbox caches. Concurrent runs could clobber each other's writes, a partially-finished install could leave a poisoned cache that never recovered on its own, and `clean` was a blunt all-or-nothing command.

This reworks the cache layer to be safe under concurrent use: metadata updates run inside a file lock with atomic temp-file-then-rename writes, and packages and exec sandboxes install into a staging directory that's atomically renamed into place, so a failed install can't leave anything broken behind. `clean` also gets an interactive Prompts flow and path-guarded deletion that stays inside the cpx cache root.