### PR TITLE
Drive Composer through composer/composer instead of a global binary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^8.3",
-        "composer/composer": "^2.0",
+        "composer/composer": "^2.8",
         "laravel/prompts": "^0.3.21",
         "symfony/console": "^7.4|^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "require": {
         "php": "^8.3",
+        "composer/composer": "^2.0",
         "laravel/prompts": "^0.3.21",
         "symfony/console": "^7.4|^8.0"
     },

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -19,8 +19,7 @@ class UpgradeCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('Updating <info>cpx</info>');
-        ComposerRunner::run(['global', 'update', 'cpx/cpx']);
 
-        return self::SUCCESS;
+        return ComposerRunner::run(['global', 'update', 'cpx/cpx']);
     }
 }

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cpx\Commands;
 
 use Cpx\Composer\ComposerRunner;
+use Cpx\Composer\ComposerSource;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,6 @@ class UpgradeCommand extends Command
     {
         $output->writeln('Updating <info>cpx</info>');
 
-        return ComposerRunner::run(['global', 'update', 'cpx/cpx']);
+        return ComposerRunner::run(['global', 'update', 'cpx/cpx'], source: ComposerSource::Device);
     }
 }

--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Cpx\Composer;
 
 use Closure;
-use Composer\InstalledVersions;
 use Cpx\Exceptions\ComposerCommandException;
 use Cpx\Process\ProcessRunner;
-use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 
 class ComposerRunner
@@ -17,13 +15,11 @@ class ComposerRunner
     private static ?Closure $fake = null;
 
     /**
-     * Run a Composer command in an isolated cpx child process.
-     *
      * @param  list<string>  $arguments
      *
      * @throws ComposerCommandException
      */
-    public static function run(array $arguments, ?string $directory = null): int
+    public static function run(array $arguments, ?string $directory = null, ComposerSource $source = ComposerSource::Bundled): int
     {
         $command = [...$arguments, '--no-interaction'];
 
@@ -33,7 +29,7 @@ class ComposerRunner
 
         $exitCode = self::$fake !== null
             ? (self::$fake)($command)
-            : (new ProcessRunner)->run([PHP_BINARY, self::composerBinary(), ...$command]);
+            : (new ProcessRunner)->run([...$source->binary(), ...$command]);
 
         if ($exitCode !== Command::SUCCESS) {
             throw new ComposerCommandException($arguments);
@@ -99,16 +95,5 @@ class ComposerRunner
         $version = is_array($lockData) ? ($lockData['packages'][0]['version'] ?? null) : null;
 
         return is_string($version) ? $version : $unknown;
-    }
-
-    private static function composerBinary(): string
-    {
-        $path = InstalledVersions::getInstallPath('composer/composer');
-
-        if ($path === null) {
-            throw new RuntimeException('Unable to locate the bundled Composer binary.');
-        }
-
-        return "{$path}/bin/composer";
     }
 }

--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Cpx\Composer;
 
 use Closure;
-use Composer\Console\Application;
-use Exception;
+use Composer\InstalledVersions;
+use Cpx\Exceptions\ComposerCommandException;
+use Cpx\Process\ProcessRunner;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\ArgvInput;
 
 class ComposerRunner
 {
@@ -16,7 +16,11 @@ class ComposerRunner
     private static ?Closure $fake = null;
 
     /**
+     * Run a Composer command in an isolated cpx child process.
+     *
      * @param  list<string>  $arguments
+     *
+     * @throws ComposerCommandException
      */
     public static function run(array $arguments, ?string $directory = null): int
     {
@@ -26,11 +30,12 @@ class ComposerRunner
             $command[] = "--working-dir={$directory}";
         }
 
-        $runner = self::$fake ?? self::execute(...);
-        $exitCode = $runner($command);
+        $exitCode = self::$fake !== null
+            ? (self::$fake)($command)
+            : (new ProcessRunner)->run([PHP_BINARY, self::composerBinary(), ...$command]);
 
         if ($exitCode !== Command::SUCCESS) {
-            throw new Exception('Composer command failed: '.implode(' ', $arguments));
+            throw new ComposerCommandException('Composer command failed: '.implode(' ', $arguments));
         }
 
         return $exitCode;
@@ -95,23 +100,14 @@ class ComposerRunner
         return is_string($version) ? $version : $unknown;
     }
 
-    /**
-     * @param  list<string>  $command
-     */
-    private static function execute(array $command): int
+    private static function composerBinary(): string
     {
-        $workingDirectory = getcwd();
+        $path = InstalledVersions::getInstallPath('composer/composer');
 
-        try {
-            $application = new Application;
-            $application->setAutoExit(false);
-            $application->setCatchExceptions(true);
-
-            return $application->run(new ArgvInput(['composer', ...$command]));
-        } finally {
-            if ($workingDirectory !== false) {
-                chdir($workingDirectory);
-            }
+        if ($path === null) {
+            throw new ComposerCommandException('Unable to locate the bundled Composer binary.');
         }
+
+        return "{$path}/bin/composer";
     }
 }

--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -4,30 +4,49 @@ declare(strict_types=1);
 
 namespace Cpx\Composer;
 
-use Cpx\Process\ProcessRunner;
+use Closure;
+use Composer\Console\Application;
 use Exception;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
 
 class ComposerRunner
 {
+    /** @var (Closure(list<string>): int)|null */
+    private static ?Closure $fake = null;
+
     /**
      * @param  list<string>  $arguments
      */
     public static function run(array $arguments, ?string $directory = null): int
     {
-        $command = ['composer', ...$arguments, '--no-interaction'];
+        $command = [...$arguments, '--no-interaction'];
 
         if ($directory !== null) {
             $command[] = "--working-dir={$directory}";
         }
 
-        $exitCode = (new ProcessRunner)->run($command);
+        $runner = self::$fake ?? self::execute(...);
+        $exitCode = $runner($command);
 
         if ($exitCode !== Command::SUCCESS) {
             throw new Exception('Composer command failed: '.implode(' ', $arguments));
         }
 
         return $exitCode;
+    }
+
+    /**
+     * @param  Closure(list<string>): int  $runner
+     */
+    public static function fake(Closure $runner): void
+    {
+        self::$fake = $runner;
+    }
+
+    public static function clearFake(): void
+    {
+        self::$fake = null;
     }
 
     /** @return list<string> */
@@ -74,5 +93,25 @@ class ComposerRunner
         $version = is_array($lockData) ? ($lockData['packages'][0]['version'] ?? null) : null;
 
         return is_string($version) ? $version : $unknown;
+    }
+
+    /**
+     * @param  list<string>  $command
+     */
+    private static function execute(array $command): int
+    {
+        $workingDirectory = getcwd();
+
+        try {
+            $application = new Application;
+            $application->setAutoExit(false);
+            $application->setCatchExceptions(true);
+
+            return $application->run(new ArgvInput(['composer', ...$command]));
+        } finally {
+            if ($workingDirectory !== false) {
+                chdir($workingDirectory);
+            }
+        }
     }
 }

--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -8,6 +8,7 @@ use Closure;
 use Composer\InstalledVersions;
 use Cpx\Exceptions\ComposerCommandException;
 use Cpx\Process\ProcessRunner;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 
 class ComposerRunner
@@ -35,7 +36,7 @@ class ComposerRunner
             : (new ProcessRunner)->run([PHP_BINARY, self::composerBinary(), ...$command]);
 
         if ($exitCode !== Command::SUCCESS) {
-            throw new ComposerCommandException('Composer command failed: '.implode(' ', $arguments));
+            throw new ComposerCommandException($arguments);
         }
 
         return $exitCode;
@@ -105,7 +106,7 @@ class ComposerRunner
         $path = InstalledVersions::getInstallPath('composer/composer');
 
         if ($path === null) {
-            throw new ComposerCommandException('Unable to locate the bundled Composer binary.');
+            throw new RuntimeException('Unable to locate the bundled Composer binary.');
         }
 
         return "{$path}/bin/composer";

--- a/src/Composer/ComposerSource.php
+++ b/src/Composer/ComposerSource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Composer;
+
+use Composer\InstalledVersions;
+use RuntimeException;
+
+enum ComposerSource
+{
+    case Bundled;
+    case Device;
+
+    /** @return list<string> */
+    public function binary(): array
+    {
+        return match ($this) {
+            self::Bundled => [PHP_BINARY, self::bundledComposerPath()],
+            self::Device => ['composer'],
+        };
+    }
+
+    private static function bundledComposerPath(): string
+    {
+        $path = InstalledVersions::getInstallPath('composer/composer');
+
+        if ($path === null) {
+            throw new RuntimeException('Unable to locate the bundled Composer binary.');
+        }
+
+        return "{$path}/bin/composer";
+    }
+}

--- a/src/Exceptions/ComposerCommandException.php
+++ b/src/Exceptions/ComposerCommandException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Exceptions;
+
+use Exception;
+
+class ComposerCommandException extends Exception
+{
+    //
+}

--- a/src/Exceptions/ComposerCommandException.php
+++ b/src/Exceptions/ComposerCommandException.php
@@ -8,5 +8,11 @@ use Exception;
 
 class ComposerCommandException extends Exception
 {
-    //
+    /**
+     * @param  list<string>  $arguments
+     */
+    public function __construct(array $arguments)
+    {
+        parent::__construct('Composer command failed: '.implode(' ', $arguments));
+    }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -34,6 +34,6 @@ if (! function_exists('cpx_path')) {
             throw new RuntimeException('Unable to determine the home directory; set the HOME or CPX_HOME environment variable.');
         }
 
-        return "{$home}/.cpx/".trim($path, '/');
+        return rtrim("{$home}/.cpx/".trim($path, '/'), '/');
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ if (! function_exists('cpx_path')) {
         $home = $_SERVER['HOME'] ?? getenv('HOME');
 
         if (! is_string($home) || $home === '') {
-            $home = __DIR__;
+            throw new RuntimeException('Unable to determine the home directory; set the HOME environment variable.');
         }
 
         return "{$home}/.cpx/".trim($path, '/');

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,10 +22,16 @@ if (! function_exists('composer_require')) {
 if (! function_exists('cpx_path')) {
     function cpx_path(string $path = ''): string
     {
+        $cpxHome = $_SERVER['CPX_HOME'] ?? getenv('CPX_HOME');
+
+        if (is_string($cpxHome) && $cpxHome !== '') {
+            return rtrim($cpxHome, '/').'/'.trim($path, '/');
+        }
+
         $home = $_SERVER['HOME'] ?? getenv('HOME');
 
         if (! is_string($home) || $home === '') {
-            throw new RuntimeException('Unable to determine the home directory; set the HOME environment variable.');
+            throw new RuntimeException('Unable to determine the home directory; set the HOME or CPX_HOME environment variable.');
         }
 
         return "{$home}/.cpx/".trim($path, '/');

--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ if (! function_exists('cpx_path')) {
         $cpxHome = $_SERVER['CPX_HOME'] ?? getenv('CPX_HOME');
 
         if (is_string($cpxHome) && $cpxHome !== '') {
-            return rtrim($cpxHome, '/').'/'.trim($path, '/');
+            return rtrim(rtrim($cpxHome, '/').'/'.trim($path, '/'), '/');
         }
 
         $home = $_SERVER['HOME'] ?? getenv('HOME');

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,13 +22,12 @@ if (! function_exists('composer_require')) {
 if (! function_exists('cpx_path')) {
     function cpx_path(string $path = ''): string
     {
-        $composerHome = $_SERVER['COMPOSER_HOME'] ?? getenv('COMPOSER_HOME');
+        $home = $_SERVER['HOME'] ?? getenv('HOME');
 
-        if (! is_string($composerHome) || $composerHome === '') {
-            $home = $_SERVER['HOME'] ?? null;
-            $composerHome = is_string($home) && $home !== '' ? $home : __DIR__;
+        if (! is_string($home) || $home === '') {
+            $home = __DIR__;
         }
 
-        return "{$composerHome}/.cpx/".trim($path, '/');
+        return "{$home}/.cpx/".trim($path, '/');
     }
 }

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -42,11 +42,6 @@ test('only the process runner calls proc_open', function () {
     expect($offenders)->toBe([]);
 });
 
-test('the composer runner runs in-process and no longer spawns a composer subprocess', function () {
-    expect(sourceFilesContaining('ProcessRunner'))
-        ->not->toContain('src/Composer/ComposerRunner.php');
-});
-
 /**
  * @return list<string>
  */

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -42,6 +42,11 @@ test('only the process runner calls proc_open', function () {
     expect($offenders)->toBe([]);
 });
 
+test('the composer runner runs in-process and no longer spawns a composer subprocess', function () {
+    expect(sourceFilesContaining('ProcessRunner'))
+        ->not->toContain('src/Composer/ComposerRunner.php');
+});
+
 /**
  * @return list<string>
  */

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -89,19 +89,41 @@ test('update reports when there are no packages to update', function () {
         ->and($output)->toContain('There are no packages to update.');
 });
 
-test('upgrade runs the composer global update command', function () {
-    $binDirectory = $this->temporaryDirectory('cpx-bin');
-    $logFile = $this->temporaryDirectory('cpx-log').'/composer.log';
-
-    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', implode(' ', array_slice(\$argv, 1))); exit(0);\n");
-
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+test('upgrade runs the composer global update command in-process', function () {
+    $calls = [];
+    fakeComposer($calls);
 
     [$status, $output] = runCpxCommand(['upgrade']);
 
     expect($status)->toBe(0)
         ->and($output)->toContain('Updating')
-        ->and(file_get_contents($logFile))->toContain('global update cpx/cpx');
+        ->and($calls)->toBe([['global', 'update', 'cpx/cpx', '--no-interaction']]);
+});
+
+test('upgrade surfaces a non-zero status when the composer update fails', function () {
+    $calls = [];
+    fakeComposer($calls, exitCode: 1);
+
+    [$status] = runCpxCommand(['upgrade']);
+
+    expect($status)->not->toBe(0)
+        ->and($calls)->toBe([['global', 'update', 'cpx/cpx', '--no-interaction']]);
+});
+
+test('update requests a composer update for each installed package directory', function () {
+    $this->useIsolatedComposerHome();
+
+    prepareCachedPackage('laravel/pint', ['pint']);
+
+    $calls = [];
+    fakeComposer($calls);
+
+    [$status] = runCpxCommand(['update']);
+
+    expect($status)->toBe(0)
+        ->and($calls)->toHaveCount(1)
+        ->and($calls[0][0])->toBe('update')
+        ->and($calls[0])->toContain('--working-dir='.cpx_path('laravel/pint/latest'));
 });
 
 test('exec runs inline php code', function () {
@@ -240,17 +262,14 @@ test('package-target version options are forwarded instead of rendering cpx vers
 });
 
 test('package-looking values with shell metacharacters fail before composer execution', function () {
-    $binDirectory = $this->temporaryDirectory('cpx-bin');
-    $logFile = $this->temporaryDirectory('cpx-log').'/composer.log';
-
-    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', 'called'); exit(0);\n");
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+    $calls = [];
+    fakeComposer($calls);
 
     [$status, $output] = runCpxCommand(['vendor/package;touch injected']);
 
     expect($status)->toBe(1)
         ->and($output)->toContain('Unrecognised command vendor/package;touch injected')
-        ->and(file_exists($logFile))->toBeFalse();
+        ->and($calls)->toBe([]);
 });
 
 test('invalid fallback commands return a failure status with help output', function () {

--- a/tests/Feature/ComposerRequireTest.php
+++ b/tests/Feature/ComposerRequireTest.php
@@ -6,9 +6,8 @@ use Cpx\Cache\Metadata;
 test('composer_require installs into a safe sandbox key and records a typed exec entry', function () {
     $this->useIsolatedComposerHome();
 
-    $binDirectory = $this->temporaryDirectory('cpx-bin');
-    writeExecutable($binDirectory.'/composer', composerAutoloaderStub());
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+    $calls = [];
+    fakeComposer($calls);
 
     composer_require('laravel/pint');
 
@@ -20,5 +19,8 @@ test('composer_require installs into a safe sandbox key and records a typed exec
         ->and($sandbox->key)->toBe($key)
         ->and($sandbox->packages)->toBe(['laravel/pint'])
         ->and($sandbox->lastRunAt)->not->toBeNull()
-        ->and(file_exists(cpx_path(".exec_cache/{$key}/vendor/autoload.php")))->toBeTrue();
+        ->and(file_exists(cpx_path(".exec_cache/{$key}/vendor/autoload.php")))->toBeTrue()
+        ->and($calls)->toHaveCount(1)
+        ->and($calls[0][0])->toBe('require')
+        ->and($calls[0][1])->toBe('laravel/pint');
 });

--- a/tests/Feature/PartialInstallTest.php
+++ b/tests/Feature/PartialInstallTest.php
@@ -7,9 +7,8 @@ use Symfony\Component\Console\Output\BufferedOutput;
 test('a failed install leaves no final dir, no staging residue, and records nothing', function () {
     $this->useIsolatedComposerHome();
 
-    $binDirectory = $this->temporaryDirectory('cpx-bin');
-    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php exit(1);\n");
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+    $calls = [];
+    fakeComposer($calls, exitCode: 1);
 
     $package = Package::parse('laravel/pint');
 
@@ -17,15 +16,16 @@ test('a failed install leaves no final dir, no staging residue, and records noth
 
     expect(is_dir($package->installPath()))->toBeFalse()
         ->and(glob(cpx_path('laravel/pint/*.installing.*')) ?: [])->toBe([])
-        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse()
+        ->and($calls)->toHaveCount(1)
+        ->and($calls[0][0])->toBe('require');
 });
 
 test('a successful install atomically populates the final dir and records last_updated', function () {
     $this->useIsolatedComposerHome();
 
-    $binDirectory = $this->temporaryDirectory('cpx-bin');
-    writeExecutable($binDirectory.'/composer', composerAutoloaderStub());
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+    $calls = [];
+    fakeComposer($calls);
 
     $package = Package::parse('laravel/pint');
     $package->installOrUpdatePackage(new BufferedOutput);
@@ -44,9 +44,8 @@ test('an install dir missing the autoloader is treated as incomplete and re-stag
     Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate($package));
     mkdir($package->installPath().'/vendor', 0755, true);
 
-    $binDirectory = $this->temporaryDirectory('cpx-bin');
-    writeExecutable($binDirectory.'/composer', composerAutoloaderStub());
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+    $calls = [];
+    fakeComposer($calls);
 
     $package->installOrUpdatePackage(new BufferedOutput);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cpx\Application;
+use Cpx\Composer\ComposerRunner;
 use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -33,15 +34,27 @@ function writeExecutable(string $path, string $contents): void
 }
 
 /**
- * A fake `composer` that writes a working autoloader into the install directory it is given.
+ * Fake the in-process Composer runner; record each call's argv and write an autoloader on success.
+ *
+ * @param  list<list<string>>  $calls
  */
-function composerAutoloaderStub(): string
+function fakeComposer(array &$calls, int $exitCode = 0): void
 {
-    return "#!/usr/bin/env php\n<?php\n"
-        ."\$dir = null;\n"
-        ."foreach (\$argv as \$arg) { if (strncmp(\$arg, '--working-dir=', 14) === 0) { \$dir = substr(\$arg, 14); } }\n"
-        ."if (\$dir !== null) { @mkdir(\$dir.'/vendor', 0755, true); file_put_contents(\$dir.'/vendor/autoload.php', '<?php'); }\n"
-        .'exit(0);'."\n";
+    ComposerRunner::fake(function (array $command) use (&$calls, $exitCode): int {
+        $calls[] = $command;
+
+        if ($exitCode === 0) {
+            foreach ($command as $argument) {
+                if (str_starts_with($argument, '--working-dir=')) {
+                    $directory = substr($argument, strlen('--working-dir='));
+                    @mkdir("{$directory}/vendor", 0755, true);
+                    file_put_contents("{$directory}/vendor/autoload.php", '<?php');
+                }
+            }
+        }
+
+        return $exitCode;
+    });
 }
 
 /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Cpx\Composer\ComposerRunner;
 use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\Terminal;
@@ -35,6 +36,8 @@ abstract class TestCase extends BaseTestCase
 
     protected function tearDown(): void
     {
+        ComposerRunner::clearFake();
+
         if ($this->workingDirectory !== null) {
             chdir($this->workingDirectory);
         }
@@ -103,6 +106,36 @@ abstract class TestCase extends BaseTestCase
         $this->workingDirectory ??= getcwd() ?: null;
 
         chdir($directory);
+    }
+
+    /**
+     * Build a staging dir that resolves the given packages from local path repos (offline, no Packagist).
+     *
+     * @param  list<string>  $packages
+     */
+    protected function stagingWithPathPackages(array $packages): string
+    {
+        $repositories = [];
+
+        foreach ($packages as $package) {
+            $fixture = $this->temporaryDirectory('cpx-fixture');
+            file_put_contents("{$fixture}/composer.json", json_encode([
+                'name' => $package,
+                'version' => '1.0.0',
+            ], JSON_THROW_ON_ERROR));
+
+            $repositories[] = ['type' => 'path', 'url' => $fixture, 'options' => ['symlink' => false]];
+        }
+
+        $repositories[] = ['packagist.org' => false];
+
+        $staging = $this->temporaryDirectory('cpx-staging');
+        file_put_contents("{$staging}/composer.json", json_encode([
+            'repositories' => $repositories,
+            'config' => ['allow-plugins' => true],
+        ], JSON_THROW_ON_ERROR));
+
+        return $staging;
     }
 
     private function deleteDirectory(string $directory): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -83,6 +83,7 @@ abstract class TestCase extends BaseTestCase
 
         $this->setEnvironmentVariable('HOME', $home);
         $this->setEnvironmentVariable('COMPOSER_HOME', $composerHome);
+        $this->setEnvironmentVariable('CPX_HOME', '');
 
         return $composerHome;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -109,8 +109,6 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Build a staging dir that resolves the given packages from local path repos (offline, no Packagist).
-     *
      * @param  list<string>  $packages
      */
     protected function stagingWithPathPackages(array $packages): string
@@ -136,6 +134,58 @@ abstract class TestCase extends BaseTestCase
         ], JSON_THROW_ON_ERROR));
 
         return $staging;
+    }
+
+    /**
+     * @return array{staging: string, package: string, pluginClass: string}
+     */
+    protected function stagingWithPluginPackage(): array
+    {
+        $suffix = bin2hex(random_bytes(6));
+        $package = "cpx-fixture/plugin-{$suffix}";
+        $pluginClass = "CpxFixture\\Plugin{$suffix}";
+
+        $fixture = $this->temporaryDirectory('cpx-plugin');
+        mkdir("{$fixture}/src", 0755, true);
+
+        file_put_contents("{$fixture}/composer.json", json_encode([
+            'name' => $package,
+            'version' => '1.0.0',
+            'type' => 'composer-plugin',
+            'require' => ['composer-plugin-api' => '^2.0'],
+            'extra' => ['class' => $pluginClass],
+            'autoload' => ['psr-4' => ['CpxFixture\\' => 'src/']],
+        ], JSON_THROW_ON_ERROR));
+
+        file_put_contents("{$fixture}/src/Plugin{$suffix}.php", <<<PHP
+        <?php
+
+        namespace CpxFixture;
+
+        use Composer\\Composer;
+        use Composer\\IO\\IOInterface;
+        use Composer\\Plugin\\PluginInterface;
+
+        class Plugin{$suffix} implements PluginInterface
+        {
+            public function activate(Composer \$composer, IOInterface \$io): void {}
+
+            public function deactivate(Composer \$composer, IOInterface \$io): void {}
+
+            public function uninstall(Composer \$composer, IOInterface \$io): void {}
+        }
+        PHP);
+
+        $staging = $this->temporaryDirectory('cpx-plugin-staging');
+        file_put_contents("{$staging}/composer.json", json_encode([
+            'repositories' => [
+                ['type' => 'path', 'url' => $fixture, 'options' => ['symlink' => false]],
+                ['packagist.org' => false],
+            ],
+            'config' => ['allow-plugins' => [$package => true]],
+        ], JSON_THROW_ON_ERROR));
+
+        return ['staging' => $staging, 'package' => $package, 'pluginClass' => $pluginClass];
     }
 
     private function deleteDirectory(string $directory): void

--- a/tests/Unit/ComposerRunnerTest.php
+++ b/tests/Unit/ComposerRunnerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Cpx\Composer\ComposerRunner;
+use Cpx\Exceptions\ComposerCommandException;
 
 test('it assembles arguments with no-interaction and working-dir and returns the runner exit code', function () {
     $captured = null;
@@ -41,21 +42,21 @@ test('it throws a uniform message when the runner reports a failure', function (
     ComposerRunner::fake(fn (array $command): int => 12);
 
     ComposerRunner::run(['update']);
-})->throws(Exception::class, 'Composer command failed: update');
+})->throws(ComposerCommandException::class, 'Composer command failed: update');
 
-test('it runs an offline composer command in-process and returns success', function () {
+test('it runs an offline composer command in an isolated child process and returns success', function () {
     $this->useIsolatedComposerHome();
 
     expect(ComposerRunner::run(['about', '--quiet']))->toBe(0);
 });
 
-test('it throws the uniform message when an unknown composer command fails in-process', function () {
+test('it throws the uniform message when an unknown composer command fails in the child', function () {
     $this->useIsolatedComposerHome();
 
     ComposerRunner::run(['this-command-does-not-exist', '--quiet']);
-})->throws(Exception::class, 'Composer command failed: this-command-does-not-exist');
+})->throws(ComposerCommandException::class, 'Composer command failed: this-command-does-not-exist');
 
-test('it installs a package in-process from a local path repository without network', function () {
+test('it installs a package from a local path repository without network', function () {
     $this->useIsolatedComposerHome();
 
     $staging = $this->stagingWithPathPackages(['cpx-fixture/pkg']);
@@ -67,19 +68,19 @@ test('it installs a package in-process from a local path repository without netw
         ->and(file_exists("{$staging}/vendor/cpx-fixture/pkg/composer.json"))->toBeTrue();
 });
 
-test('it restores the working directory even when a working-dir command fails', function () {
+test('it leaves the calling process working directory untouched when a working-dir command fails', function () {
     $this->useIsolatedComposerHome();
 
     $before = getcwd();
     $staging = $this->temporaryDirectory('cpx-cwd');
 
     expect(fn () => ComposerRunner::run(['this-command-does-not-exist', '--quiet'], $staging))
-        ->toThrow(Exception::class);
+        ->toThrow(ComposerCommandException::class);
 
     expect(getcwd())->toBe($before);
 });
 
-test('it installs multiple packages sequentially in the same process', function () {
+test('it installs multiple packages across isolated child processes', function () {
     $this->useIsolatedComposerHome();
 
     $staging = $this->stagingWithPathPackages(['cpx-fixture/one', 'cpx-fixture/two']);
@@ -91,7 +92,19 @@ test('it installs multiple packages sequentially in the same process', function 
         ->and(file_exists("{$staging}/vendor/cpx-fixture/two/composer.json"))->toBeTrue();
 });
 
-test('it runs global composer commands in-process against COMPOSER_HOME', function () {
+test('it activates package plugins in the child without loading them into the cpx process', function () {
+    $this->useIsolatedComposerHome();
+
+    ['staging' => $staging, 'package' => $package, 'pluginClass' => $pluginClass] = $this->stagingWithPluginPackage();
+
+    $exitCode = ComposerRunner::run(['require', "{$package}:*", '--quiet'], $staging);
+
+    expect($exitCode)->toBe(0)
+        ->and(file_exists("{$staging}/vendor/{$package}/composer.json"))->toBeTrue()
+        ->and(class_exists($pluginClass, autoload: false))->toBeFalse();
+});
+
+test('it runs global composer commands in the child against COMPOSER_HOME', function () {
     $composerHome = $this->useIsolatedComposerHome();
 
     ComposerRunner::run(['global', 'config', 'sort-packages', 'true', '--quiet']);

--- a/tests/Unit/ComposerRunnerTest.php
+++ b/tests/Unit/ComposerRunnerTest.php
@@ -1,49 +1,102 @@
 <?php
 
+declare(strict_types=1);
+
 use Cpx\Composer\ComposerRunner;
-use Cpx\Packages\Package;
-use Symfony\Component\Console\Output\NullOutput;
 
-test('it passes composer arguments as argv tokens', function () {
-    $binDirectory = $this->temporaryDirectory('cpx-composer-bin');
-    $workingDirectory = $this->temporaryDirectory('cpx-composer working;dir');
-    $logFile = $this->temporaryDirectory('cpx-composer-log').'/argv.json';
+test('it assembles arguments with no-interaction and working-dir and returns the runner exit code', function () {
+    $captured = null;
+    ComposerRunner::fake(function (array $command) use (&$captured): int {
+        $captured = $command;
 
-    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', json_encode(array_slice(\$argv, 1), JSON_THROW_ON_ERROR)); exit(0);\n");
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+        return 0;
+    });
 
-    $exitCode = ComposerRunner::run(['require', 'vendor/package:^1@dev', '--no-progress'], $workingDirectory);
+    $exitCode = ComposerRunner::run(['require', 'vendor/package:^1@dev', '--no-progress'], '/tmp/example dir');
 
     expect($exitCode)->toBe(0)
-        ->and(json_decode((string) file_get_contents($logFile), true))->toBe([
+        ->and($captured)->toBe([
             'require',
             'vendor/package:^1@dev',
             '--no-progress',
             '--no-interaction',
-            "--working-dir={$workingDirectory}",
+            '--working-dir=/tmp/example dir',
         ]);
 });
 
-test('it throws when composer exits non-zero', function () {
-    $binDirectory = $this->temporaryDirectory('cpx-composer-bin');
+test('it omits the working-dir option when no directory is given', function () {
+    $captured = null;
+    ComposerRunner::fake(function (array $command) use (&$captured): int {
+        $captured = $command;
 
-    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php fwrite(STDERR, 'composer failed'); exit(12);\n");
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+        return 0;
+    });
+
+    ComposerRunner::run(['update']);
+
+    expect($captured)->toBe(['update', '--no-interaction']);
+});
+
+test('it throws a uniform message when the runner reports a failure', function () {
+    ComposerRunner::fake(fn (array $command): int => 12);
 
     ComposerRunner::run(['update']);
 })->throws(Exception::class, 'Composer command failed: update');
 
-test('package installation calls composer with argv arrays', function () {
+test('it runs an offline composer command in-process and returns success', function () {
     $this->useIsolatedComposerHome();
 
-    $binDirectory = $this->temporaryDirectory('cpx-composer-bin');
-    $logFile = $this->temporaryDirectory('cpx-composer-log').'/argv.json';
+    expect(ComposerRunner::run(['about', '--quiet']))->toBe(0);
+});
 
-    writeExecutable($binDirectory.'/composer', "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', json_encode(array_slice(\$argv, 1), JSON_THROW_ON_ERROR)); exit(0);\n");
-    $this->setEnvironmentVariable('PATH', $binDirectory.PATH_SEPARATOR.getenv('PATH'));
+test('it throws the uniform message when an unknown composer command fails in-process', function () {
+    $this->useIsolatedComposerHome();
 
-    Package::parse('vendor/package:^1@dev')->installOrUpdatePackage(new NullOutput, updateCheck: false);
+    ComposerRunner::run(['this-command-does-not-exist', '--quiet']);
+})->throws(Exception::class, 'Composer command failed: this-command-does-not-exist');
 
-    expect(json_decode((string) file_get_contents($logFile), true))->toContain('vendor/package:^1@dev')
-        ->and(json_decode((string) file_get_contents($logFile), true))->not->toContain('vendor/package:^1@dev --no-interaction');
+test('it installs a package in-process from a local path repository without network', function () {
+    $this->useIsolatedComposerHome();
+
+    $staging = $this->stagingWithPathPackages(['cpx-fixture/pkg']);
+
+    $exitCode = ComposerRunner::run(['require', 'cpx-fixture/pkg:*', '--quiet'], $staging);
+
+    expect($exitCode)->toBe(0)
+        ->and(file_exists("{$staging}/vendor/autoload.php"))->toBeTrue()
+        ->and(file_exists("{$staging}/vendor/cpx-fixture/pkg/composer.json"))->toBeTrue();
+});
+
+test('it restores the working directory even when a working-dir command fails', function () {
+    $this->useIsolatedComposerHome();
+
+    $before = getcwd();
+    $staging = $this->temporaryDirectory('cpx-cwd');
+
+    expect(fn () => ComposerRunner::run(['this-command-does-not-exist', '--quiet'], $staging))
+        ->toThrow(Exception::class);
+
+    expect(getcwd())->toBe($before);
+});
+
+test('it installs multiple packages sequentially in the same process', function () {
+    $this->useIsolatedComposerHome();
+
+    $staging = $this->stagingWithPathPackages(['cpx-fixture/one', 'cpx-fixture/two']);
+
+    ComposerRunner::run(['require', 'cpx-fixture/one:*', '--quiet'], $staging);
+    ComposerRunner::run(['require', 'cpx-fixture/two:*', '--quiet'], $staging);
+
+    expect(file_exists("{$staging}/vendor/cpx-fixture/one/composer.json"))->toBeTrue()
+        ->and(file_exists("{$staging}/vendor/cpx-fixture/two/composer.json"))->toBeTrue();
+});
+
+test('it runs global composer commands in-process against COMPOSER_HOME', function () {
+    $composerHome = $this->useIsolatedComposerHome();
+
+    ComposerRunner::run(['global', 'config', 'sort-packages', 'true', '--quiet']);
+
+    expect(file_exists("{$composerHome}/composer.json"))->toBeTrue()
+        ->and(json_decode((string) file_get_contents("{$composerHome}/composer.json"), true))
+        ->toHaveKey('config.sort-packages');
 });

--- a/tests/Unit/ComposerRunnerTest.php
+++ b/tests/Unit/ComposerRunnerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Cpx\Composer\ComposerRunner;
+use Cpx\Composer\ComposerSource;
 use Cpx\Exceptions\ComposerCommandException;
 
 test('it assembles arguments with no-interaction and working-dir and returns the runner exit code', function () {
@@ -48,6 +49,12 @@ test('it runs an offline composer command in an isolated child process and retur
     $this->useIsolatedComposerHome();
 
     expect(ComposerRunner::run(['about', '--quiet']))->toBe(0);
+});
+
+test('it runs a command with the device composer', function () {
+    $this->useIsolatedComposerHome();
+
+    expect(ComposerRunner::run(['about', '--quiet'], source: ComposerSource::Device))->toBe(0);
 });
 
 test('it throws the uniform message when an unknown composer command fails in the child', function () {

--- a/tests/Unit/CpxPathTest.php
+++ b/tests/Unit/CpxPathTest.php
@@ -53,6 +53,14 @@ test('cpx_path with no argument does not produce a trailing slash with CPX_HOME'
     expect(cpx_path())->toBe($cpxHome);
 });
 
+test('cpx_path with no argument does not produce a trailing slash with HOME', function () {
+    $home = $this->temporaryDirectory('cpx-home');
+    $this->setEnvironmentVariable('HOME', $home);
+    $this->setEnvironmentVariable('CPX_HOME', '');
+
+    expect(cpx_path())->toBe("{$home}/.cpx");
+});
+
 test('it fails loudly when neither CPX_HOME nor the home directory can be resolved', function () {
     $this->setEnvironmentVariable('CPX_HOME', '');
     $this->setEnvironmentVariable('HOME', '');

--- a/tests/Unit/CpxPathTest.php
+++ b/tests/Unit/CpxPathTest.php
@@ -46,6 +46,13 @@ test('it falls back to the user home when CPX_HOME is empty', function () {
     expect(cpx_path('metadata.json'))->toBe("{$home}/.cpx/metadata.json");
 });
 
+test('cpx_path with no argument does not produce a trailing slash with CPX_HOME', function () {
+    $cpxHome = $this->temporaryDirectory('cpx-home-override');
+    $this->setEnvironmentVariable('CPX_HOME', $cpxHome);
+
+    expect(cpx_path())->toBe($cpxHome);
+});
+
 test('it fails loudly when neither CPX_HOME nor the home directory can be resolved', function () {
     $this->setEnvironmentVariable('CPX_HOME', '');
     $this->setEnvironmentVariable('HOME', '');

--- a/tests/Unit/CpxPathTest.php
+++ b/tests/Unit/CpxPathTest.php
@@ -14,3 +14,10 @@ test('it resolves cpx state independently of composer home', function () {
 
     expect(cpx_path('metadata.json'))->toBe("{$home}/.cpx/metadata.json");
 });
+
+test('it fails loudly when the home directory cannot be resolved', function () {
+    $this->setEnvironmentVariable('HOME', '');
+
+    expect(fn () => cpx_path('metadata.json'))
+        ->toThrow(RuntimeException::class, 'Unable to determine the home directory; set the HOME environment variable.');
+});

--- a/tests/Unit/CpxPathTest.php
+++ b/tests/Unit/CpxPathTest.php
@@ -11,13 +11,45 @@ test('it resolves cpx state independently of composer home', function () {
     $home = $this->temporaryDirectory('cpx-home');
     $this->setEnvironmentVariable('HOME', $home);
     $this->setEnvironmentVariable('COMPOSER_HOME', $this->temporaryDirectory('composer-elsewhere'));
+    $this->setEnvironmentVariable('CPX_HOME', '');
 
     expect(cpx_path('metadata.json'))->toBe("{$home}/.cpx/metadata.json");
 });
 
-test('it fails loudly when the home directory cannot be resolved', function () {
+test('it stores cpx state under CPX_HOME when set', function () {
+    $cpxHome = $this->temporaryDirectory('cpx-home-override');
+    $this->setEnvironmentVariable('CPX_HOME', $cpxHome);
+
+    expect(cpx_path('metadata.json'))->toBe("{$cpxHome}/metadata.json");
+});
+
+test('CPX_HOME takes precedence over the user home directory', function () {
+    $cpxHome = $this->temporaryDirectory('cpx-home-override');
+    $this->setEnvironmentVariable('HOME', $this->temporaryDirectory('cpx-home'));
+    $this->setEnvironmentVariable('CPX_HOME', $cpxHome);
+
+    expect(cpx_path('metadata.json'))->toBe("{$cpxHome}/metadata.json");
+});
+
+test('it trims a trailing slash from CPX_HOME', function () {
+    $cpxHome = $this->temporaryDirectory('cpx-home-override');
+    $this->setEnvironmentVariable('CPX_HOME', "{$cpxHome}/");
+
+    expect(cpx_path('metadata.json'))->toBe("{$cpxHome}/metadata.json");
+});
+
+test('it falls back to the user home when CPX_HOME is empty', function () {
+    $home = $this->temporaryDirectory('cpx-home');
+    $this->setEnvironmentVariable('HOME', $home);
+    $this->setEnvironmentVariable('CPX_HOME', '');
+
+    expect(cpx_path('metadata.json'))->toBe("{$home}/.cpx/metadata.json");
+});
+
+test('it fails loudly when neither CPX_HOME nor the home directory can be resolved', function () {
+    $this->setEnvironmentVariable('CPX_HOME', '');
     $this->setEnvironmentVariable('HOME', '');
 
     expect(fn () => cpx_path('metadata.json'))
-        ->toThrow(RuntimeException::class, 'Unable to determine the home directory; set the HOME environment variable.');
+        ->toThrow(RuntimeException::class, 'Unable to determine the home directory; set the HOME or CPX_HOME environment variable.');
 });

--- a/tests/Unit/CpxPathTest.php
+++ b/tests/Unit/CpxPathTest.php
@@ -1,7 +1,16 @@
 <?php
 
-test('it stores cpx state under composer home when available', function () {
-    $composerHome = $this->useIsolatedComposerHome();
+test('it stores cpx state under the user home directory', function () {
+    $this->useIsolatedComposerHome();
+    $home = getenv('HOME');
 
-    expect(cpx_path('metadata.json'))->toBe("{$composerHome}/.cpx/metadata.json");
+    expect(cpx_path('metadata.json'))->toBe("{$home}/.cpx/metadata.json");
+});
+
+test('it resolves cpx state independently of composer home', function () {
+    $home = $this->temporaryDirectory('cpx-home');
+    $this->setEnvironmentVariable('HOME', $home);
+    $this->setEnvironmentVariable('COMPOSER_HOME', $this->temporaryDirectory('composer-elsewhere'));
+
+    expect(cpx_path('metadata.json'))->toBe("{$home}/.cpx/metadata.json");
 });


### PR DESCRIPTION
cpx shelled out to a `composer` binary on `PATH` to install, update, and self-update packages. That made a working global Composer install a hard runtime requirement and blocked the move toward a self-contained PHAR.

This drives the bundled `composer/composer` directly instead. Each Composer command runs in an isolated child process, so a package's Composer plugins and autoloaders load and die with that child rather than leaking into the long-lived cpx process. cpx state lives under `~/.cpx` (independent of `COMPOSER_HOME`), can be relocated with the new `CPX_HOME` variable, and cpx now fails with a clear message when no home directory can be resolved.