### PR TITLE
Allow aliasing a specific binary of multi-binary packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,12 @@
     "require": {
         "php": "^8.3",
         "composer/composer": "^2.8",
+        "laravel/prompts": "^0.3.21",
         "symfony/console": "^7.4|^8.0"
     },
     "require-dev": {
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.29",
-        "laravel/prompts": "^0.3.21",
         "mockery/mockery": "^1.6",
         "pestphp/pest": "^4.7",
         "pestphp/pest-plugin-type-coverage": "^4.0",

--- a/src/Commands/AliasCommand.php
+++ b/src/Commands/AliasCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\warning;
 
@@ -32,6 +33,7 @@ class AliasCommand extends Command
     {
         $this->addArgument('package', InputArgument::OPTIONAL, 'The package to alias, e.g. <vendor>/<package>[:version]');
         $this->addArgument('name', InputArgument::OPTIONAL, 'The alias name to run the package as, e.g. "cpx <name>"');
+        $this->addOption('bin', null, InputOption::VALUE_REQUIRED, 'The binary to run when the package exposes more than one');
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite an existing alias without confirmation');
     }
 
@@ -42,34 +44,89 @@ class AliasCommand extends Command
         try {
             $package = $this->resolvePackage($input);
             $name = $this->resolveName($input, $package);
+
+            $aliases = UserAliases::open();
+
+            if (! $this->confirmOverwrite($input, $aliases, $name)) {
+                info("Alias \"{$name}\" was left unchanged.");
+
+                return self::SUCCESS;
+            }
+
+            $package = $this->resolveBinary($input, $package, $output);
         } catch (InvalidArgumentException|NonInteractiveValidationException $e) {
             error($e->getMessage());
 
             return self::FAILURE;
         }
 
-        $aliases = UserAliases::open();
-
-        if ($aliases->has($name) && ! $this->confirmOverwrite($input, $name, $aliases->find($name))) {
-            info("Alias \"{$name}\" was left unchanged.");
-
-            return self::SUCCESS;
-        }
-
         $aliases->put($name, $package)->save();
 
-        info("Alias created: cpx {$name} now runs {$package}.");
+        info("Alias created: cpx {$name} now runs {$package->displayString()}.");
 
         return self::SUCCESS;
     }
 
-    private function confirmOverwrite(InputInterface $input, string $name, ?Package $current): bool
+    private function resolveBinary(InputInterface $input, Package $package, OutputInterface $output): Package
     {
-        if ($input->getOption('force')) {
+        $binaries = array_keys($package->binaries($package->installOrUpdatePackage($output)));
+
+        if ($binaries === []) {
+            throw new InvalidArgumentException("{$package} does not provide any binaries.");
+        }
+
+        if (($bin = $input->getOption('bin')) !== null) {
+            return $package->withBin($this->ensureBinaryExists($package, $bin, $binaries));
+        }
+
+        if (count($binaries) === 1) {
+            return $package;
+        }
+
+        return $package->withBin($this->chooseBinary($input, $package, $binaries));
+    }
+
+    /**
+     * @param  list<string>  $binaries
+     */
+    private function ensureBinaryExists(Package $package, string $bin, array $binaries): string
+    {
+        if (! in_array($bin, $binaries)) {
+            throw new InvalidArgumentException(
+                "\"{$bin}\" is not a binary provided by {$package}. Available binaries: ".implode(', ', $binaries).'.',
+            );
+        }
+
+        return $bin;
+    }
+
+    /**
+     * @param  list<string>  $binaries
+     */
+    private function chooseBinary(InputInterface $input, Package $package, array $binaries): string
+    {
+        if (! $input->isInteractive()) {
+            throw new InvalidArgumentException(
+                "{$package} exposes multiple binaries (".implode(', ', $binaries).'). Choose one with the --bin option.',
+            );
+        }
+
+        return (string) select(
+            label: "Which binary of {$package} would you like to alias?",
+            options: $binaries,
+            default: in_array($package->name, $binaries, true) ? $package->name : null,
+        );
+    }
+
+    private function confirmOverwrite(InputInterface $input, UserAliases $aliases, string $name): bool
+    {
+        $current = $aliases->find($name);
+
+        if ($current === null || $input->getOption('force')) {
             return true;
         }
 
-        warning("The alias \"{$name}\" is currently mapped to {$current}.");
+        warning("The alias \"{$name}\" is currently mapped to {$current->displayString()}.");
 
         return confirm(
             label: "Do you want to overwrite the \"{$name}\" alias?",

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -41,7 +41,7 @@ class AliasesCommand extends Command
 
         foreach ($userAliases as $name => $package) {
             $paddedCommand = str_pad($name, 15);
-            $output->writeln('  <info>cpx '.$paddedCommand.'</info>   '.$package->fullPackageString());
+            $output->writeln('  <info>cpx '.$paddedCommand.'</info>   '.$package->displayString());
         }
 
         return self::SUCCESS;

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -29,6 +29,7 @@ class Package
         public string $vendor,
         public string $name,
         public ?string $version = null,
+        public ?string $bin = null,
     ) {
         //
     }
@@ -83,6 +84,40 @@ class Package
             .($this->version ? ':'.$this->version : '');
     }
 
+    public function displayString(): string
+    {
+        $result = $this->fullPackageString();
+
+        if (! is_null($this->bin)) {
+            $result .= " ({$this->bin})";
+        }
+
+        return $result;
+    }
+
+    public function withBin(?string $bin): self
+    {
+        $clone = clone $this;
+        $clone->bin = $bin;
+
+        return $clone;
+    }
+
+    public function packagePath(string $installDir): string
+    {
+        return "{$installDir}/vendor/{$this->vendor}/{$this->name}";
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function binaries(string $installDir): array
+    {
+        $binScripts = ComposerRunner::detectBinFromComposer($this->packagePath($installDir));
+
+        return Arr::mapWithKeys(fn (int $_, string $value): array => [basename($value) => $value], $binScripts);
+    }
+
     public function delete(): void
     {
         Filesystem::deleteDirectory($this->installPath());
@@ -91,8 +126,8 @@ class Package
     public function runCommand(PackageInvocation $invocation, OutputInterface $output, bool $autoUpdate = true): int
     {
         $installDir = $this->installOrUpdatePackage($output, $autoUpdate);
-        $packageDir = "{$installDir}/vendor/{$this->vendor}/{$this->name}";
-        $binScripts = ComposerRunner::detectBinFromComposer($packageDir);
+        $packageDir = $this->packagePath($installDir);
+        $binScripts = $this->binaries($installDir);
 
         if (empty($binScripts)) {
             $output->writeln("<error>No bin command found in {$this}.</error>");
@@ -100,7 +135,6 @@ class Package
             return Command::FAILURE;
         }
 
-        $binScripts = Arr::mapWithKeys(fn (int $_, string $value): array => [basename($value) => $value], $binScripts);
         $resolved = $this->resolveBinCommand($binScripts, $invocation);
 
         if ($resolved === null) {
@@ -164,6 +198,16 @@ class Package
      */
     private function resolveBinCommand(array $binScripts, PackageInvocation $invocation): ?ResolvedBin
     {
+        if ($this->bin !== null) {
+            $command = $this->matchBin($binScripts, $this->bin);
+
+            if ($command === null) {
+                throw new RuntimeException("The requested bin command '{$this->bin}' was not found in {$this}.");
+            }
+
+            return new ResolvedBin($command, $invocation);
+        }
+
         if (count($binScripts) === 1) {
             return new ResolvedBin($binScripts[array_key_first($binScripts)], $invocation);
         }

--- a/src/Packages/UserAliases.php
+++ b/src/Packages/UserAliases.php
@@ -37,16 +37,24 @@ class UserAliases
             throw new MalformedAliasesException($file);
         }
 
+        $aliases = [];
+
         foreach ($json as $name => $value) {
-            if (! is_string($name) || ! is_string($value)) {
+            if (! is_string($name) || ! is_array($value)) {
                 throw new MalformedAliasesException($file);
             }
+
+            $package = $value['package'] ?? null;
+            $bin = $value['bin'] ?? null;
+
+            if (! is_string($package) || (! is_string($bin) && $bin !== null)) {
+                throw new MalformedAliasesException($file);
+            }
+
+            $aliases[$name] = Package::parse($package)->withBin($bin);
         }
 
-        return new self(array_map(
-            fn (string $value): Package => Package::parse($value),
-            $json,
-        ));
+        return new self($aliases);
     }
 
     /** @return array<string, Package> */
@@ -84,11 +92,14 @@ class UserAliases
         Filesystem::writeAtomic(cpx_path(self::FILE), (string) json_encode($this->toArray(), JSON_PRETTY_PRINT));
     }
 
-    /** @return array<string, string> */
+    /** @return array<string, array{package: string, bin: string|null}> */
     public function toArray(): array
     {
         return array_map(
-            fn (Package $package): string => $package->fullPackageString(),
+            fn (Package $package): array => [
+                'package' => $package->fullPackageString(),
+                'bin' => $package->bin,
+            ],
             $this->aliases,
         );
     }

--- a/tests/Feature/BinaryResolutionTest.php
+++ b/tests/Feature/BinaryResolutionTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Cpx\Packages\Package;
+use Cpx\Packages\UserAliases;
+
 test('a package with one binary runs without requiring a binary name', function () {
     $this->useIsolatedComposerHome();
     $logFile = $this->temporaryDirectory('cpx-log').'/argv.json';
@@ -56,4 +59,42 @@ test('ambiguous multiple-binary packages list the available binaries', function 
 
     expect($status)->toBe(1)
         ->and($output)->toContain('More than 1 bin command found for vendor/package: foo, bar.');
+});
+
+test('an aliased multiple-binary package runs its pinned binary and forwards all arguments', function () {
+    $this->useIsolatedComposerHome();
+    $logFile = $this->temporaryDirectory('cpx-log').'/argv.json';
+
+    prepareCachedPackage('vendor/package', ['foo', 'bar'], [
+        'foo' => "#!/usr/bin/env php\n<?php exit(99);\n",
+        'bar' => "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', json_encode(array_slice(\$argv, 1), JSON_THROW_ON_ERROR)); exit(0);\n",
+    ]);
+
+    UserAliases::open()
+        ->put('tool', Package::parse('vendor/package')->withBin('bar'))
+        ->save();
+
+    // The leading positional token must reach the pinned binary rather than being
+    // consumed as a binary selector the way an unpinned multi-binary package would.
+    [$status] = runCpxCommand(['tool', 'foo', '--flag']);
+
+    expect($status)->toBe(0)
+        ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['foo', '--flag']);
+});
+
+test('an aliased package with a stale pinned binary fails with a clear error', function () {
+    $this->useIsolatedComposerHome();
+
+    prepareCachedPackage('vendor/package', ['foo'], [
+        'foo' => "#!/usr/bin/env php\n<?php exit(0);\n",
+    ]);
+
+    UserAliases::open()
+        ->put('tool', Package::parse('vendor/package')->withBin('removed'))
+        ->save();
+
+    [$status, $output] = runCpxCommand(['tool']);
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain("'removed' was not found");
 });

--- a/tests/Unit/AliasCommandTest.php
+++ b/tests/Unit/AliasCommandTest.php
@@ -14,6 +14,7 @@ function aliasCommandTester(): CommandTester
 
 test('it creates an alias non-interactively from positional arguments', function () {
     $this->useIsolatedComposerHome();
+    prepareCachedPackage('laravel/pint', ['pint']);
 
     $tester = aliasCommandTester();
     $status = $tester->execute(['package' => 'laravel/pint', 'name' => 'mypint']);
@@ -25,6 +26,7 @@ test('it creates an alias non-interactively from positional arguments', function
 
 test('it defaults the alias name to the package short name when omitted', function () {
     $this->useIsolatedComposerHome();
+    prepareCachedPackage('laravel/pint', ['pint']);
 
     $tester = aliasCommandTester();
     $status = $tester->execute(['package' => 'laravel/pint']);
@@ -57,6 +59,7 @@ test('it rejects an alias name that collides with a registered command', functio
 
 test('it allows an alias name that collides with a built-in package alias', function () {
     $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/custom-pint', ['custom-pint']);
 
     $tester = aliasCommandTester();
     $status = $tester->execute(['package' => 'vendor/custom-pint', 'name' => 'pint']);
@@ -67,6 +70,7 @@ test('it allows an alias name that collides with a built-in package alias', func
 
 test('it warns before overwriting an existing alias of the same name', function () {
     $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/two', ['two']);
 
     UserAliases::open()->put('tool', Package::parse('vendor/one'))->save();
 
@@ -80,6 +84,7 @@ test('it warns before overwriting an existing alias of the same name', function 
 
 test('it overwrites an existing user alias when --force is passed', function () {
     $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/two', ['two']);
 
     UserAliases::open()->put('tool', Package::parse('vendor/one'))->save();
 
@@ -108,4 +113,82 @@ test('it rejects an alias name with characters that would break parsing', functi
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('may only contain letters, numbers');
+});
+
+test('it pins the alias to the binary chosen with --bin for a multi-binary package', function () {
+    $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/package', ['foo', 'bar']);
+
+    $tester = aliasCommandTester();
+    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool', '--bin' => 'bar']);
+
+    expect($status)->toBe(0)
+        ->and($tester->getDisplay())->toContain('now runs vendor/package (bar)');
+
+    $alias = UserAliases::open()->find('tool');
+
+    expect($alias?->fullPackageString())->toBe('vendor/package')
+        ->and($alias?->bin)->toBe('bar');
+});
+
+test('it persists the chosen binary to the aliases file', function () {
+    $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/package', ['foo', 'bar']);
+
+    aliasCommandTester()->execute(['package' => 'vendor/package', 'name' => 'tool', '--bin' => 'foo']);
+
+    $stored = json_decode((string) file_get_contents(cpx_path('aliases.json')), true);
+
+    expect($stored)->toBe(['tool' => ['package' => 'vendor/package', 'bin' => 'foo']]);
+});
+
+test('it rejects a --bin value the package does not provide', function () {
+    $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/package', ['foo', 'bar']);
+
+    $tester = aliasCommandTester();
+    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool', '--bin' => 'baz']);
+
+    expect($status)->toBe(1)
+        ->and($tester->getDisplay())->toContain('"baz" is not a binary provided by vendor/package')
+        ->and($tester->getDisplay())->toContain('Available binaries: foo, bar.')
+        ->and(UserAliases::open()->has('tool'))->toBeFalse();
+});
+
+test('it fails for a multi-binary package when no binary is chosen non-interactively', function () {
+    $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/package', ['foo', 'bar']);
+
+    $tester = aliasCommandTester();
+    $status = $tester->setInputs([])->execute(
+        ['package' => 'vendor/package', 'name' => 'tool'],
+        ['interactive' => false],
+    );
+
+    expect($status)->toBe(1)
+        ->and($tester->getDisplay())->toContain('exposes multiple binaries (foo, bar)')
+        ->and(UserAliases::open()->has('tool'))->toBeFalse();
+});
+
+test('it rejects a package that does not provide any binaries', function () {
+    $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/package', []);
+
+    $tester = aliasCommandTester();
+    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool']);
+
+    expect($status)->toBe(1)
+        ->and($tester->getDisplay())->toContain('vendor/package does not provide any binaries.')
+        ->and(UserAliases::open()->has('tool'))->toBeFalse();
+});
+
+test('it does not require a binary choice for a single-binary package', function () {
+    $this->useIsolatedComposerHome();
+    prepareCachedPackage('vendor/package', ['only']);
+
+    $tester = aliasCommandTester();
+    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool']);
+
+    expect($status)->toBe(0)
+        ->and(UserAliases::open()->find('tool')?->bin)->toBeNull();
 });

--- a/tests/Unit/UserAliasesTest.php
+++ b/tests/Unit/UserAliasesTest.php
@@ -19,7 +19,7 @@ test('it saves and reloads a user alias', function () {
     $aliases = UserAliases::open();
 
     expect($contents)->not->toBeFalse()
-        ->and(json_decode((string) $contents, true))->toBe(['mypint' => 'laravel/pint'])
+        ->and(json_decode((string) $contents, true))->toBe(['mypint' => ['package' => 'laravel/pint', 'bin' => null]])
         ->and($aliases->has('mypint'))->toBeTrue()
         ->and($aliases->find('mypint')?->fullPackageString())->toBe('laravel/pint');
 });


### PR DESCRIPTION
`cpx alias` now supports packages with multiple binaries by letting users pin an alias to a specific binary with `--bin`, or choose one interactively.