### PR TITLE
Configure Laravel Prompts output globally

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -15,9 +15,11 @@ use Cpx\Commands\UnaliasCommand;
 use Cpx\Commands\UpdateCommand;
 use Cpx\Commands\UpgradeCommand;
 use Cpx\Packages\PackageCommandRunner;
+use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends SymfonyApplication
@@ -33,6 +35,9 @@ class Application extends SymfonyApplication
     public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         $input ??= new ArgvInput;
+        $output ??= new ConsoleOutput;
+
+        Prompt::setOutput($output);
 
         if ($input instanceof ArgvInput && $this->shouldRunPackageFallback($input)) {
             $input = new ArgvInput(['cpx', RunPackageCommand::NAME, '--', ...$input->getRawTokens()]);

--- a/src/Commands/AliasCommand.php
+++ b/src/Commands/AliasCommand.php
@@ -8,7 +8,6 @@ use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
 use InvalidArgumentException;
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
-use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -39,8 +38,6 @@ class AliasCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        Prompt::setOutput($output);
-
         try {
             $package = $this->resolvePackage($input);
             $name = $this->resolveName($input, $package);

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -7,7 +7,6 @@ namespace Cpx\Commands;
 use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
 use Laravel\Prompts\Elements\Element;
-use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,8 +22,6 @@ class AliasesCommand extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        Prompt::setOutput($output);
-
         $userAliases = UserAliases::open()->all();
 
         if ($userAliases === []) {

--- a/src/Commands/UnaliasCommand.php
+++ b/src/Commands/UnaliasCommand.php
@@ -7,7 +7,6 @@ namespace Cpx\Commands;
 use Cpx\Packages\UserAliases;
 use InvalidArgumentException;
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
-use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -31,8 +30,6 @@ class UnaliasCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        Prompt::setOutput($output);
-
         $aliases = UserAliases::open();
 
         if ($aliases->all() === []) {

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -98,10 +98,10 @@ test('the sandbox option removes exec caches but preserves package caches', func
 test('the sandbox option is a no-op when there are no sandboxes', function () {
     $this->useIsolatedComposerHome();
 
-    [$status] = runCpxCommand(['clean', '--sandbox']);
+    [$status, $output] = runCpxCommand(['clean', '--sandbox']);
 
     expect($status)->toBe(0)
-        ->and(promptOutput())->toContain('Nothing to clean');
+        ->and($output)->toContain('Nothing to clean');
 });
 
 test('a days window of zero reclaims everything older than now', function () {
@@ -169,10 +169,10 @@ test('an invalid days value is rejected before any cleanup runs', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    [$status] = runCpxCommand(['clean', '--days=abc']);
+    [$status, $output] = runCpxCommand(['clean', '--days=abc']);
 
     expect($status)->not->toBe(0)
-        ->and(promptOutput())->toContain('positive integer')
+        ->and($output)->toContain('positive integer')
         ->and(is_dir($packageDirectory))->toBeTrue();
 });
 
@@ -193,10 +193,10 @@ test('a negative days value is rejected before any cleanup runs', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    [$status] = runCpxCommand(['clean', '--days=-5']);
+    [$status, $output] = runCpxCommand(['clean', '--days=-5']);
 
     expect($status)->not->toBe(0)
-        ->and(promptOutput())->toContain('positive integer')
+        ->and($output)->toContain('positive integer')
         ->and(is_dir($packageDirectory))->toBeTrue();
 });
 
@@ -282,11 +282,11 @@ test('orphaned package directories are detected and cleaned', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    [$status] = runCpxCommand(['clean']);
+    [$status, $output] = runCpxCommand(['clean']);
 
     expect($status)->toBe(0)
         ->and(is_dir($orphan))->toBeFalse()
-        ->and(promptOutput())->toContain('orphan/package/latest');
+        ->and($output)->toContain('orphan/package/latest');
 });
 
 test('incomplete install directories are treated as orphaned and removed', function () {
@@ -341,12 +341,12 @@ test('cleanup refuses to delete paths outside the cpx cache root', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    [$status] = runCpxCommand(['clean']);
+    [$status, $output] = runCpxCommand(['clean']);
 
     expect($status)->toBe(1)
         ->and(is_dir($outside))->toBeTrue()
         ->and(file_exists($outside.'/keep.txt'))->toBeTrue()
-        ->and(promptOutput())->toContain('Could not remove');
+        ->and($output)->toContain('Could not remove');
 });
 
 test('the summary lists the caches that were removed', function () {
@@ -363,10 +363,10 @@ test('the summary lists the caches that were removed', function () {
         'execCache' => [],
     ], JSON_THROW_ON_ERROR));
 
-    [$status] = runCpxCommand(['clean']);
+    [$status, $output] = runCpxCommand(['clean']);
 
     expect($status)->toBe(0)
-        ->and(promptOutput())
+        ->and($output)
         ->toContain('Clean Summary')
         ->toContain('Removed')
         ->toContain('laravel/pint');
@@ -377,9 +377,9 @@ test('the interactive prompt shows the available clean options', function () {
 
     Prompt::fake([Key::ENTER, Key::ENTER]);
 
-    runCpxCommand(['clean']);
+    [, $output] = runCpxCommand(['clean']);
 
-    expect(promptOutput())
+    expect($output)
         ->toContain('What would you like to clean?')
         ->toContain('All cached packages and sandboxes')
         ->toContain('Only sandbox (exec) caches')
@@ -492,9 +492,9 @@ test('the interactive number prompt rejects values below one and re-prompts', fu
     // Confirm "period", clear "30", submit invalid "0" (rejected), then enter "5".
     Prompt::fake([Key::ENTER, Key::BACKSPACE, Key::BACKSPACE, '0', Key::ENTER, Key::BACKSPACE, '5', Key::ENTER]);
 
-    runCpxCommand(['clean']);
+    [, $output] = runCpxCommand(['clean']);
 
-    expect(promptOutput())->toContain('Must be at least 1')
+    expect($output)->toContain('Must be at least 1')
         ->and(is_dir($idle))->toBeFalse()
         ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse();
 });

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -117,10 +117,10 @@ test('unalias removes a user-defined alias', function () {
 test('clean reports when there are no packages to clean', function () {
     $this->useIsolatedComposerHome();
 
-    [$status] = runCpxCommand(['clean']);
+    [$status, $output] = runCpxCommand(['clean']);
 
     expect($status)->toBe(0)
-        ->and(promptOutput())->toContain('Nothing to clean');
+        ->and($output)->toContain('Nothing to clean');
 });
 
 test('update reports when there are no packages to update', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,17 +2,11 @@
 
 use Cpx\Application;
 use Cpx\Composer\ComposerRunner;
-use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature', 'Unit');
-
-function promptOutput(): string
-{
-    return Prompt::strippedContent();
-}
 
 /**
  * @param  list<string>  $arguments

--- a/tests/Unit/AliasCommandTest.php
+++ b/tests/Unit/AliasCommandTest.php
@@ -3,13 +3,11 @@
 use Cpx\Application;
 use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
-use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\ApplicationTester;
 
-function aliasCommandTester(): CommandTester
+function aliasCommandTester(): ApplicationTester
 {
-    $application = new Application;
-
-    return new CommandTester($application->find('alias'));
+    return new ApplicationTester(new Application);
 }
 
 test('it creates an alias non-interactively from positional arguments', function () {
@@ -17,7 +15,7 @@ test('it creates an alias non-interactively from positional arguments', function
     prepareCachedPackage('laravel/pint', ['pint']);
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'laravel/pint', 'name' => 'mypint']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'laravel/pint', 'name' => 'mypint']);
 
     expect($status)->toBe(0)
         ->and($tester->getDisplay())->toContain('Alias created: cpx mypint')
@@ -29,7 +27,7 @@ test('it defaults the alias name to the package short name when omitted', functi
     prepareCachedPackage('laravel/pint', ['pint']);
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'laravel/pint']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'laravel/pint']);
 
     expect($status)->toBe(0)
         ->and(UserAliases::open()->find('pint')?->fullPackageString())->toBe('laravel/pint');
@@ -39,7 +37,7 @@ test('it fails gracefully when the package is omitted outside of an interactive 
     $this->useIsolatedComposerHome();
 
     $tester = aliasCommandTester();
-    $status = $tester->execute([]);
+    $status = $tester->run(['command' => 'alias']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('A package name must be provided.')
@@ -50,7 +48,7 @@ test('it rejects an alias name that collides with a registered command', functio
     $this->useIsolatedComposerHome();
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'laravel/pint', 'name' => 'clean']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'laravel/pint', 'name' => 'clean']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('already a cpx command')
@@ -64,7 +62,7 @@ test('it warns before overwriting an existing alias of the same name', function 
     UserAliases::open()->put('tool', Package::parse('vendor/one'))->save();
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'vendor/two', 'name' => 'tool']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'vendor/two', 'name' => 'tool']);
 
     expect($status)->toBe(0)
         ->and($tester->getDisplay())->toContain('The alias "tool" is currently mapped to vendor/one.')
@@ -78,7 +76,7 @@ test('it overwrites an existing user alias when --force is passed', function () 
     UserAliases::open()->put('tool', Package::parse('vendor/one'))->save();
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'vendor/two', 'name' => 'tool', '--force' => true]);
+    $status = $tester->run(['command' => 'alias', 'package' => 'vendor/two', 'name' => 'tool', '--force' => true]);
 
     expect($status)->toBe(0)
         ->and(UserAliases::open()->find('tool')?->fullPackageString())->toBe('vendor/two');
@@ -88,7 +86,7 @@ test('it rejects an invalid package argument without prompting', function () {
     $this->useIsolatedComposerHome();
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'not-a-package']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'not-a-package']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('A package name should be in the format');
@@ -98,7 +96,7 @@ test('it rejects an alias name with characters that would break parsing', functi
     $this->useIsolatedComposerHome();
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'laravel/pint', 'name' => 'my alias!']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'laravel/pint', 'name' => 'my alias!']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('may only contain letters, numbers');
@@ -109,7 +107,7 @@ test('it pins the alias to the binary chosen with --bin for a multi-binary packa
     prepareCachedPackage('vendor/package', ['foo', 'bar']);
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool', '--bin' => 'bar']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'vendor/package', 'name' => 'tool', '--bin' => 'bar']);
 
     expect($status)->toBe(0)
         ->and($tester->getDisplay())->toContain('now runs vendor/package (bar)');
@@ -124,7 +122,7 @@ test('it persists the chosen binary to the aliases file', function () {
     $this->useIsolatedComposerHome();
     prepareCachedPackage('vendor/package', ['foo', 'bar']);
 
-    aliasCommandTester()->execute(['package' => 'vendor/package', 'name' => 'tool', '--bin' => 'foo']);
+    aliasCommandTester()->run(['command' => 'alias', 'package' => 'vendor/package', 'name' => 'tool', '--bin' => 'foo']);
 
     $stored = json_decode((string) file_get_contents(cpx_path('aliases.json')), true);
 
@@ -136,7 +134,7 @@ test('it rejects a --bin value the package does not provide', function () {
     prepareCachedPackage('vendor/package', ['foo', 'bar']);
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool', '--bin' => 'baz']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'vendor/package', 'name' => 'tool', '--bin' => 'baz']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('"baz" is not a binary provided by vendor/package')
@@ -149,8 +147,8 @@ test('it fails for a multi-binary package when no binary is chosen non-interacti
     prepareCachedPackage('vendor/package', ['foo', 'bar']);
 
     $tester = aliasCommandTester();
-    $status = $tester->setInputs([])->execute(
-        ['package' => 'vendor/package', 'name' => 'tool'],
+    $status = $tester->setInputs([])->run(
+        ['command' => 'alias', 'package' => 'vendor/package', 'name' => 'tool'],
         ['interactive' => false],
     );
 
@@ -164,7 +162,7 @@ test('it rejects a package that does not provide any binaries', function () {
     prepareCachedPackage('vendor/package', []);
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'vendor/package', 'name' => 'tool']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('vendor/package does not provide any binaries.')
@@ -176,7 +174,7 @@ test('it does not require a binary choice for a single-binary package', function
     prepareCachedPackage('vendor/package', ['only']);
 
     $tester = aliasCommandTester();
-    $status = $tester->execute(['package' => 'vendor/package', 'name' => 'tool']);
+    $status = $tester->run(['command' => 'alias', 'package' => 'vendor/package', 'name' => 'tool']);
 
     expect($status)->toBe(0)
         ->and(UserAliases::open()->find('tool')?->bin)->toBeNull();

--- a/tests/Unit/UnaliasCommandTest.php
+++ b/tests/Unit/UnaliasCommandTest.php
@@ -3,13 +3,11 @@
 use Cpx\Application;
 use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
-use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\ApplicationTester;
 
-function unaliasCommandTester(): CommandTester
+function unaliasCommandTester(): ApplicationTester
 {
-    $application = new Application;
-
-    return new CommandTester($application->find('unalias'));
+    return new ApplicationTester(new Application);
 }
 
 test('it removes an existing alias by name', function () {
@@ -18,7 +16,7 @@ test('it removes an existing alias by name', function () {
     UserAliases::open()->put('mypint', Package::parse('laravel/pint'))->save();
 
     $tester = unaliasCommandTester();
-    $status = $tester->execute(['name' => 'mypint']);
+    $status = $tester->run(['command' => 'unalias', 'name' => 'mypint']);
 
     expect($status)->toBe(0)
         ->and($tester->getDisplay())->toContain('Alias "mypint" removed.')
@@ -31,7 +29,7 @@ test('it fails when the named alias does not exist among other saved aliases', f
     UserAliases::open()->put('mypint', Package::parse('laravel/pint'))->save();
 
     $tester = unaliasCommandTester();
-    $status = $tester->execute(['name' => 'missing']);
+    $status = $tester->run(['command' => 'unalias', 'name' => 'missing']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('No alias named "missing" was found.');
@@ -43,7 +41,7 @@ test('it fails gracefully when the name is omitted outside of an interactive ter
     UserAliases::open()->put('mypint', Package::parse('laravel/pint'))->save();
 
     $tester = unaliasCommandTester();
-    $status = $tester->execute([]);
+    $status = $tester->run(['command' => 'unalias']);
 
     expect($status)->toBe(1)
         ->and($tester->getDisplay())->toContain('An alias name must be provided.')
@@ -54,7 +52,7 @@ test('it reports there is nothing to remove when no aliases exist and the argume
     $this->useIsolatedComposerHome();
 
     $tester = unaliasCommandTester();
-    $status = $tester->execute([]);
+    $status = $tester->run(['command' => 'unalias']);
 
     expect($status)->toBe(0)
         ->and($tester->getDisplay())->toContain('You have no aliases to remove.');
@@ -64,7 +62,7 @@ test('it reports there is nothing to remove when no aliases exist even if a name
     $this->useIsolatedComposerHome();
 
     $tester = unaliasCommandTester();
-    $status = $tester->execute(['name' => 'mypint']);
+    $status = $tester->run(['command' => 'unalias', 'name' => 'mypint']);
 
     expect($status)->toBe(0)
         ->and($tester->getDisplay())->toContain('You have no aliases to remove.');


### PR DESCRIPTION
Move `Prompt::setOutput()` into `Application::run()` so all commands share the application output. Update tests to assert against the global output stream.