### PR TITLE
Display a friendly error when a package cannot be found

### DIFF
--- a/src/Commands/AliasCommand.php
+++ b/src/Commands/AliasCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cpx\Commands;
 
+use Cpx\Exceptions\PackageNotFoundException;
 use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
 use InvalidArgumentException;
@@ -53,6 +54,10 @@ class AliasCommand extends Command
             }
 
             $package = $this->resolveBinary($input, $package);
+        } catch (PackageNotFoundException $e) {
+            $e->render();
+
+            return self::FAILURE;
         } catch (InvalidArgumentException|NonInteractiveValidationException $e) {
             error($e->getMessage());
 

--- a/src/Exceptions/PackageNotFoundException.php
+++ b/src/Exceptions/PackageNotFoundException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Exceptions;
+
+use Cpx\Packages\Package;
+use Exception;
+use Laravel\Prompts\Elements\Link;
+use Throwable;
+
+use function Laravel\Prompts\callout;
+
+class PackageNotFoundException extends Exception
+{
+    public function __construct(public readonly Package $package, ?Throwable $previous = null)
+    {
+        parent::__construct("The package \"{$package->fullPackageString()}\" could not be found.", previous: $previous);
+    }
+
+    public function render(): void
+    {
+        callout(
+            label: 'Package not found',
+            content: [
+                "Composer was unable to install `{$this->package->fullPackageString()}`.",
+                $this->hint(),
+                new Link("https://packagist.org/packages/{$this->package->vendor}/{$this->package->name}"),
+            ],
+            type: 'error',
+        );
+    }
+
+    private function hint(): string
+    {
+        return $this->package->version === null
+            ? 'Make sure the package name is spelled correctly and the package is published on Packagist:'
+            : "Make sure the package name is spelled correctly and a version matching `{$this->package->version}` is published on Packagist:";
+    }
+}

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -6,6 +6,8 @@ namespace Cpx\Packages;
 
 use Cpx\Cache\Metadata;
 use Cpx\Composer\ComposerRunner;
+use Cpx\Exceptions\ComposerCommandException;
+use Cpx\Exceptions\PackageNotFoundException;
 use Cpx\Input\PackageInvocation;
 use Cpx\Process\ProcessRunner;
 use Cpx\Support\Arr;
@@ -128,7 +130,13 @@ class Package
 
     public function runCommand(PackageInvocation $invocation, bool $autoUpdate = true): int
     {
-        $installDir = $this->installOrUpdatePackage($autoUpdate);
+        try {
+            $installDir = $this->installOrUpdatePackage($autoUpdate);
+        } catch (PackageNotFoundException $exception) {
+            $exception->render();
+
+            return Command::FAILURE;
+        }
         $packageDir = $this->packagePath($installDir);
         $binScripts = $this->binaries($installDir);
 
@@ -259,7 +267,9 @@ class Package
         } catch (Throwable $exception) {
             Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
 
-            throw $exception;
+            throw $exception instanceof ComposerCommandException
+                ? new PackageNotFoundException($this, previous: $exception)
+                : $exception;
         }
     }
 

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -335,3 +335,35 @@ test('invalid fallback commands return a failure status with help output', funct
     expect($status)->toBe(1)
         ->and($output)->toContain('Unrecognised command not-a-package');
 });
+
+test('a package that composer cannot install renders a package-not-found error', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls, exitCode: 1);
+
+    [$status, $output] = runCpxCommand(['foo/bar']);
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Package not found')
+        ->and($output)->toContain('Composer was unable to install')
+        ->and($output)->toContain('`foo/bar`')
+        ->and($output)->toContain('spelled correctly')
+        ->and($output)->toContain('https://packagist.org/packages/foo/bar')
+        ->and($output)->not->toContain('__cpx_run_package');
+});
+
+test('a package-not-found error mentions the requested version constraint', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls, exitCode: 1);
+
+    [$status, $output] = runCpxCommand(['foo/bar:^9.0']);
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Package not found')
+        ->and($output)->toContain('version matching')
+        ->and($output)->toContain('`^9.0`')
+        ->and($output)->toContain('https://packagist.org/packages/foo/bar');
+});


### PR DESCRIPTION
## Summary

Running `cpx foo/bar` with a package that doesn't exist on Packagist previously dumped a raw Symfony exception:

<img width="1027" height="517" alt="bettershot_1783689125482" src="https://github.com/user-attachments/assets/25b8ad19-17c4-4a43-b89c-c8b1b75c5d15" />

---

This PR make it display a friendly error when a package cannot be found:

<img width="1367" height="635" alt="bettershot_1783690035193" src="https://github.com/user-attachments/assets/7b78e33a-d126-4e0d-86dd-e3e23a366085" />
