### PR TITLE
Render local binary runs with task() like global runs

### DIFF
--- a/src/Packages/PackageCommandRunner.php
+++ b/src/Packages/PackageCommandRunner.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\error;
-use function Laravel\Prompts\info;
+use function Laravel\Prompts\task;
 
 /**
  * Runs a non-built-in cpx target by resolving it to a local PHP file, a local
@@ -63,7 +63,11 @@ class PackageCommandRunner
 
     private function runLocal(ResolvedBin $resolved): int
     {
-        info('Running '.basename($resolved->command)." from {$resolved->command}");
+        task(
+            label: 'Running '.basename($resolved->command)." from {$resolved->command}",
+            callback: fn (): bool => true,
+            keepSummary: true,
+        );
 
         return (new ProcessRunner)->run(BinExecutable::commandFor($resolved->command, $resolved->invocation->forwardedTokens()));
     }


### PR DESCRIPTION
When cpx runs a package from a local project install, the progress was printed as a plain `info()` message, while global runs render it via `task()`.

---

This PR updates the local run path to use `task()`:

<img width="1851" height="719" alt="bettershot_1783940339178" src="https://github.com/user-attachments/assets/ecec3a6c-1e20-408b-be47-03b427a3a70a" />

This aligns it with a global run:

<img width="1844" height="610" alt="bettershot_1783940518113" src="https://github.com/user-attachments/assets/c2cea595-5a9e-437f-ada4-79990ff37be5" />

Previously:

<img width="1860" height="742" alt="bettershot_1783940555354" src="https://github.com/user-attachments/assets/10721399-7048-4336-9bcb-684c9e867d06" />
