### PR TITLE
Fix `cpx clean` removing execCache entries regardless of age

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -27,8 +27,10 @@ class CleanCommand extends Command
             }
         }
 
-        foreach ($metadata->execCache as $sandboxDir => $packageMetadata) {
-            $lastRun = strtotime($packageMetadata->lastRunAt ?? '1970-01-01 00:00:00');
+        foreach ($metadata->execCache as $sandboxDir => $cacheEntry) {
+            $lastRun = is_array($cacheEntry)
+                ? (int) ($cacheEntry['last_run'] ?? 0)
+                : strtotime($cacheEntry->lastRunAt ?? '1970-01-01 00:00:00');
 
             if ($this->console->hasOption('all') || $lastRun < $timeLimit) {
                 $packageDirectory = cpx_path(".exec_cache/{$sandboxDir}");


### PR DESCRIPTION
`CleanCommand` reads execCache metadata using object access (`$packageMetadata->lastRunAt`) but execCache entries are stored as plain arrays. As a result, the property is never read correctly, and the fallback value `1970-01-01` is used instead. This causes the condition to always evaluate to true, and every execCache entry is cleaned regardless of actual age.