### PR TITLE
Prompt for the binary to run when a package has multiple bins

### DIFF
--- a/src/Packages/LocalPackage.php
+++ b/src/Packages/LocalPackage.php
@@ -129,6 +129,8 @@ class LocalPackage extends Package
             throw new RuntimeException("The requested bin command '{$this->bin}' was not found in {$this}.");
         }
 
+        $resolved ??= $this->chooseBinCommand($this->localBinaries, $invocation);
+
         if ($resolved === null) {
             return Result::failure($output, "More than 1 bin command found in {$this->root}: ".implode(', ', array_keys($this->localBinaries)).'.');
         }

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -15,12 +15,14 @@ use Cpx\Support\Filesystem;
 use Cpx\Support\Interactivity;
 use Cpx\Support\Result;
 use InvalidArgumentException;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Support\Logger;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\task;
 
 class Package
@@ -150,7 +152,8 @@ class Package
             return Result::failure($output, "No bin command found in {$this}.");
         }
 
-        $resolved = $this->resolveBinCommand($binScripts, $invocation);
+        $resolved = $this->resolveBinCommand($binScripts, $invocation)
+            ?? $this->chooseBinCommand($binScripts, $invocation);
 
         if ($resolved === null) {
             return Result::failure($output, "More than 1 bin command found for {$this}: ".implode(', ', array_keys($binScripts)).'.');
@@ -207,6 +210,29 @@ class Package
         }
 
         return (time() - $lastUpdatedAt) > Metadata::UPDATE_CHECK_INTERVAL;
+    }
+
+    /**
+     * @param  array<string, string>  $binScripts
+     */
+    protected function chooseBinCommand(array $binScripts, PackageInvocation $invocation): ?ResolvedBin
+    {
+        if (! Interactivity::isInteractive()) {
+            return null;
+        }
+
+        try {
+            $chosen = select(
+                label: "Which command would you like to run from {$this}?",
+                options: array_keys($binScripts),
+            );
+        } catch (NonInteractiveValidationException) {
+            return null;
+        }
+
+        $command = $binScripts[$chosen] ?? null;
+
+        return $command === null ? null : new ResolvedBin($command, $invocation);
     }
 
     /**

--- a/tests/Feature/BinaryResolutionTest.php
+++ b/tests/Feature/BinaryResolutionTest.php
@@ -2,6 +2,8 @@
 
 use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
 
 test('a package with one binary runs without requiring a binary name', function () {
     $this->useIsolatedComposerHome();
@@ -47,7 +49,25 @@ test('a package with multiple binaries keeps a positional argument when a binary
         ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['tests/Sub']);
 });
 
-test('ambiguous multiple-binary packages list the available binaries', function () {
+test('ambiguous multiple-binary packages prompt for the binary to run', function () {
+    $this->useIsolatedComposerHome();
+    $logFile = $this->temporaryDirectory('cpx-log').'/argv.json';
+
+    prepareCachedPackage('vendor/package', ['foo', 'bar'], [
+        'foo' => noopBinary(99),
+        'bar' => argvLoggingBinary($logFile),
+    ]);
+
+    Prompt::fake([Key::DOWN, Key::ENTER]);
+
+    [$status, $output] = runCpxCommand(['vendor/package', '--flag']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Which command would you like to run from vendor/package?')
+        ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['--flag']);
+})->skipOnWindows();
+
+test('ambiguous multiple-binary packages list the available binaries when the terminal cannot prompt', function () {
     $this->useIsolatedComposerHome();
 
     prepareCachedPackage('vendor/package', ['foo', 'bar'], [

--- a/tests/Feature/LocalPackageDirectoryTest.php
+++ b/tests/Feature/LocalPackageDirectoryTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Cpx\Packages\BinExecutable;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
 
 test('an aliased local package directory runs from its saved source without invoking composer', function () {
     $this->useIsolatedComposerHome();
@@ -175,7 +177,23 @@ test('the first forwarded token selects a binary from a local multi-bin package'
         ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['--flag']);
 });
 
-test('an ambiguous local multi-bin package lists its binaries', function () {
+test('an ambiguous local multi-bin package prompts for the binary to run', function () {
+    $root = $this->prepareLocalPackage(['bin/foo', 'bin/bar'], 'vendor/package');
+    $logFile = $this->temporaryDirectory('cpx-log').'/argv.json';
+
+    $this->writeLocalPackageBinary($root, 'bin/foo', noopBinary(99));
+    $this->writeLocalPackageBinary($root, 'bin/bar', argvLoggingBinary($logFile));
+
+    Prompt::fake([Key::DOWN, Key::ENTER]);
+
+    [$status, $output] = runCpxCommand([$root, '--flag']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Which command would you like to run from')
+        ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['--flag']);
+})->skipOnWindows();
+
+test('an ambiguous local multi-bin package lists its binaries when the terminal cannot prompt', function () {
     $root = $this->prepareLocalPackage(['bin/foo', 'bin/bar'], 'vendor/package');
 
     $this->writeLocalPackageBinary($root, 'bin/foo', noopBinary());


### PR DESCRIPTION
When a package provides multiple binaries and cpx can't determine which one to run, it now prompts you to choose in interactive terminals instead of failing.

<img width="1367" height="495" alt="bettershot_1784626181631" src="https://github.com/user-attachments/assets/5178b193-1fbc-4818-adf2-f42b6d1291f6" />

Non-interactive, `--json`, and agent runs continue to fail as before, and aliases with a pinned binary (`--bin=`) are unaffected.