### PR TITLE
Only show package-not-found errors for missing packages

### DIFF
--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -8,6 +8,8 @@ use Closure;
 use Composer\Console\Application as ComposerApplication;
 use Composer\InstalledVersions;
 use Cpx\Exceptions\ComposerCommandException;
+use Cpx\Exceptions\PackageNotFoundException;
+use Cpx\Process\ProcessResult;
 use Cpx\Process\ProcessRunner;
 use Cpx\Runtime\Environment;
 use RuntimeException;
@@ -19,8 +21,36 @@ class ComposerRunner
 {
     public const REINVOKE_TOKEN = '__cpx_run_composer';
 
-    /** @var (Closure(list<string>): int)|null */
+    /** @var (Closure(list<string>): (int|ProcessResult))|null */
     private static ?Closure $fake = null;
+
+    /**
+     * @throws ComposerCommandException
+     * @throws PackageNotFoundException
+     */
+    public static function require(string $package, string $directory): int
+    {
+        $arguments = ['require', $package];
+        $result = self::execute($arguments, $directory, captureOutput: true);
+
+        if ($result->exitCode === Command::SUCCESS) {
+            return $result->exitCode;
+        }
+
+        $exception = new ComposerCommandException($arguments);
+        $missingPackage = self::missingPackage($result->output);
+
+        if ($missingPackage === null) {
+            throw $exception;
+        }
+
+        $requestedPackage = explode(':', $package, 2)[0];
+
+        throw PackageNotFoundException::fromPackageString(
+            strcasecmp($requestedPackage, $missingPackage) === 0 ? $package : $missingPackage,
+            previous: $exception,
+        );
+    }
 
     /**
      * @param  list<string>  $arguments
@@ -29,15 +59,7 @@ class ComposerRunner
      */
     public static function run(array $arguments, ?string $directory = null): int
     {
-        $command = [...$arguments, '--no-interaction'];
-
-        if ($directory !== null) {
-            $command[] = "--working-dir={$directory}";
-        }
-
-        $exitCode = self::$fake !== null
-            ? (self::$fake)($command)
-            : (new ProcessRunner)->run([...self::composerBinary(), ...$command]);
+        $exitCode = self::execute($arguments, $directory, captureOutput: false)->exitCode;
 
         if ($exitCode !== Command::SUCCESS) {
             throw new ComposerCommandException($arguments);
@@ -58,7 +80,7 @@ class ComposerRunner
     }
 
     /**
-     * @param  Closure(list<string>): int  $runner
+     * @param  Closure(list<string>): (int|ProcessResult)  $runner
      */
     public static function fake(Closure $runner): void
     {
@@ -122,6 +144,50 @@ class ComposerRunner
         }
 
         return $unknown;
+    }
+
+    /**
+     * @param  list<string>  $arguments
+     */
+    private static function execute(array $arguments, ?string $directory, bool $captureOutput): ProcessResult
+    {
+        $command = [...$arguments, '--no-interaction'];
+
+        if ($directory !== null) {
+            $command[] = "--working-dir={$directory}";
+        }
+
+        if (self::$fake !== null) {
+            $result = (self::$fake)($command);
+
+            return is_int($result) ? new ProcessResult($result, '') : $result;
+        }
+
+        $runner = new ProcessRunner;
+        $processCommand = [...self::composerBinary(), ...$command];
+
+        return $captureOutput
+            ? $runner->runWithOutput($processCommand)
+            : new ProcessResult($runner->run($processCommand), '');
+    }
+
+    private static function missingPackage(string $output): ?string
+    {
+        $output = preg_replace('/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -\/]*[@-~])/', '', $output) ?? $output;
+        $output = preg_replace('/\s+/', ' ', $output) ?? $output;
+        $package = '(?<package>[a-z0-9](?:[_.-]?[a-z0-9]+)*\/[a-z0-9](?:(?:[_.]?|-{0,2})[a-z0-9]+)*)';
+
+        foreach ([
+            '/Could not find package '.$package.'\./i',
+            '/Could not find a matching version of package '.$package.'\./i',
+            '/requires '.$package.'(?: (?:(?! -> |, it ).)+)?(?:, it| ->) could not be found in any version, there may be a typo in the package name\./i',
+        ] as $pattern) {
+            if (preg_match($pattern, $output, $matches) === 1) {
+                return $matches['package'];
+            }
+        }
+
+        return null;
     }
 
     /** @return list<string> */

--- a/src/Exceptions/PackageNotFoundException.php
+++ b/src/Exceptions/PackageNotFoundException.php
@@ -18,6 +18,11 @@ class PackageNotFoundException extends Exception
         parent::__construct("The package \"{$package->fullPackageString()}\" could not be found.", previous: $previous);
     }
 
+    public static function fromPackageString(string $package, ?Throwable $previous = null): self
+    {
+        return new self(Package::parse($package), $previous);
+    }
+
     public function render(): void
     {
         callout(

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -6,7 +6,6 @@ namespace Cpx\Packages;
 
 use Cpx\Cache\Metadata;
 use Cpx\Composer\ComposerRunner;
-use Cpx\Exceptions\ComposerCommandException;
 use Cpx\Exceptions\PackageNotFoundException;
 use Cpx\Input\PackageInvocation;
 use Cpx\Process\ProcessRunner;
@@ -265,13 +264,11 @@ class Package
         ]));
 
         try {
-            ComposerRunner::run(['require', $this->fullPackageString()], $stagingDir);
+            ComposerRunner::require($this->fullPackageString(), $stagingDir);
         } catch (Throwable $exception) {
             Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
 
-            throw $exception instanceof ComposerCommandException
-                ? new PackageNotFoundException($this, previous: $exception)
-                : $exception;
+            throw $exception;
         }
     }
 

--- a/src/Process/ProcessResult.php
+++ b/src/Process/ProcessResult.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Process;
+
+readonly class ProcessResult
+{
+    public function __construct(
+        public int $exitCode,
+        public string $output,
+    ) {}
+}

--- a/src/Process/ProcessRunner.php
+++ b/src/Process/ProcessRunner.php
@@ -40,33 +40,16 @@ class ProcessRunner
      */
     public function run(array $command, array $env = [], ?string $cwd = null): int
     {
-        if (self::$fakeRunner !== null) {
-            return (self::$fakeRunner)($command, $env, $cwd);
-        }
+        return $this->execute($command, $env, $cwd, captureOutput: false)->exitCode;
+    }
 
-        if ($this->isMissingExecutable($command[0] ?? null)) {
-            return self::COULD_NOT_EXECUTE;
-        }
-
-        try {
-            $process = new Process($command, cwd: $cwd, env: $env === [] ? null : $env, timeout: null);
-
-            if (static::$logger !== null) {
-                return $process->run($this->logOutput(...));
-            }
-
-            if (self::$fakeInput === null && Interactivity::isInteractive() && Process::isTtySupported()) {
-                $process->setTty(true);
-
-                return $process->run();
-            }
-
-            $process->setInput(self::$fakeInput ?? STDIN);
-
-            return $process->run($this->writeOutput(...));
-        } catch (ExceptionInterface) {
-            return self::COULD_NOT_EXECUTE;
-        }
+    /**
+     * @param  list<string>  $command
+     * @param  array<string, string|false>  $env
+     */
+    public function runWithOutput(array $command, array $env = [], ?string $cwd = null): ProcessResult
+    {
+        return $this->execute($command, $env, $cwd, captureOutput: true);
     }
 
     /**
@@ -90,6 +73,58 @@ class ProcessRunner
     public static function clearFakeInput(): void
     {
         self::$fakeInput = null;
+    }
+
+    /**
+     * @param  list<string>  $command
+     * @param  array<string, string|false>  $env
+     */
+    private function execute(array $command, array $env, ?string $cwd, bool $captureOutput): ProcessResult
+    {
+        if (self::$fakeRunner !== null) {
+            return new ProcessResult((self::$fakeRunner)($command, $env, $cwd), '');
+        }
+
+        if ($this->isMissingExecutable($command[0] ?? null)) {
+            return new ProcessResult(self::COULD_NOT_EXECUTE, '');
+        }
+
+        try {
+            $process = new Process($command, cwd: $cwd, env: $env === [] ? null : $env, timeout: null);
+
+            if (static::$logger !== null) {
+                $output = '';
+                $exitCode = $process->run(function (string $type, string $buffer) use (&$output, $captureOutput): void {
+                    if ($captureOutput) {
+                        $output .= $buffer;
+                    }
+
+                    $this->logOutput($type, $buffer);
+                });
+
+                return new ProcessResult($exitCode, $output);
+            }
+
+            if (! $captureOutput && self::$fakeInput === null && Interactivity::isInteractive() && Process::isTtySupported()) {
+                $process->setTty(true);
+
+                return new ProcessResult($process->run(), '');
+            }
+
+            $process->setInput(self::$fakeInput ?? STDIN);
+            $output = '';
+            $exitCode = $process->run(function (string $type, string $buffer) use (&$output, $captureOutput): void {
+                if ($captureOutput) {
+                    $output .= $buffer;
+                }
+
+                $this->writeOutput($type, $buffer);
+            });
+
+            return new ProcessResult($exitCode, $output);
+        } catch (ExceptionInterface) {
+            return new ProcessResult(self::COULD_NOT_EXECUTE, '');
+        }
     }
 
     private function isMissingExecutable(?string $command): bool

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -6,6 +6,7 @@ use Cpx\Input\PackageInvocation;
 use Cpx\Packages\Package;
 use Cpx\Packages\PackageCommandRunner;
 use Cpx\Packages\UserAliases;
+use Cpx\Process\ProcessResult;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -348,4 +349,19 @@ test('a package-not-found error mentions the requested version constraint', func
         ->and($output)->toContain('version matching')
         ->and($output)->toContain('`^9.0`')
         ->and($output)->toContain('https://packagist.org/packages/foo/bar');
+});
+
+test('a composer failure for an existing package is not rendered as package-not-found', function () {
+    $this->useIsolatedComposerHome();
+
+    ComposerRunner::fake(fn (array $command): ProcessResult => new ProcessResult(
+        1,
+        'Root composer.json requires foo/bar ^9.0, found foo/bar[1.0.0] but it does not match the constraint.',
+    ));
+
+    [$status, $output] = runCpxCommand(['foo/bar:^9.0']);
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Composer command failed: require foo/bar:^9.0')
+        ->and($output)->not->toContain('Package not found');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 use Cpx\Application;
 use Cpx\Composer\ComposerRunner;
+use Cpx\Process\ProcessResult;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Tests\TestCase;
@@ -72,7 +73,7 @@ function noopBinary(int $exitCode = 0): string
  */
 function fakeComposer(array &$calls, int $exitCode = 0): void
 {
-    ComposerRunner::fake(function (array $command) use (&$calls, $exitCode): int {
+    ComposerRunner::fake(function (array $command) use (&$calls, $exitCode): int|ProcessResult {
         $calls[] = $command;
 
         if ($exitCode === 0) {
@@ -83,6 +84,12 @@ function fakeComposer(array &$calls, int $exitCode = 0): void
                     file_put_contents("{$directory}/vendor/autoload.php", '<?php');
                 }
             }
+        }
+
+        if ($exitCode !== 0 && ($command[0] ?? null) === 'require') {
+            $package = explode(':', $command[1] ?? 'vendor/missing', 2)[0];
+
+            return new ProcessResult($exitCode, "Could not find a matching version of package {$package}.");
         }
 
         return $exitCode;

--- a/tests/Unit/ComposerRunnerTest.php
+++ b/tests/Unit/ComposerRunnerTest.php
@@ -4,7 +4,30 @@ declare(strict_types=1);
 
 use Cpx\Composer\ComposerRunner;
 use Cpx\Exceptions\ComposerCommandException;
+use Cpx\Exceptions\PackageNotFoundException;
+use Cpx\Process\ProcessResult;
+use Cpx\Process\ProcessRunner;
+use Cpx\Support\SilentLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
+
+test('it runs the require command', function () {
+    $captured = null;
+    ComposerRunner::fake(function (array $command) use (&$captured): int {
+        $captured = $command;
+
+        return 0;
+    });
+
+    $exitCode = ComposerRunner::require('vendor/package:^1.0', '/tmp/example');
+
+    expect($exitCode)->toBe(0)
+        ->and($captured)->toBe([
+            'require',
+            'vendor/package:^1.0',
+            '--no-interaction',
+            '--working-dir=/tmp/example',
+        ]);
+});
 
 test('it assembles arguments with no-interaction and working-dir and returns the runner exit code', function () {
     $captured = null;
@@ -44,6 +67,116 @@ test('it throws a uniform message when the runner reports a failure', function (
 
     ComposerRunner::run(['update']);
 })->throws(ComposerCommandException::class, 'Composer command failed: update');
+
+test('it identifies composer package discovery failures', function (string $requirement, string $diagnostic) {
+    ComposerRunner::fake(fn (array $command): ProcessResult => new ProcessResult(1, $diagnostic));
+
+    ComposerRunner::require($requirement, '/tmp/example');
+})->with([
+    'unversioned package' => ['vendor/missing', 'Could not find a matching version of package vendor/missing. Check the package spelling.'],
+    'suggested package names' => ['vendor/missing', "Could not find package vendor/missing.\n\nDid you mean vendor/existing?"],
+    'explicit version' => ['vendor/missing:^9.0', 'Root composer.json requires vendor/missing ^9.0, it could not be found in any version, there may be a typo in the package name.'],
+    'ansi-decorated multiline output' => ['vendor/missing', "\e[31mRoot composer.json requires\e[39m\n vendor/missing, it could not be found in any version,\n there may be a typo in the package name."],
+])->throws(PackageNotFoundException::class);
+
+test('a package-not-found failure retains the requested constraint and composer exception', function () {
+    ComposerRunner::fake(fn (array $command): ProcessResult => new ProcessResult(1, 'Could not find a matching version of package vendor/missing.'));
+
+    try {
+        ComposerRunner::require('vendor/missing:^9.0', '/tmp/example');
+    } catch (PackageNotFoundException $exception) {
+        expect($exception->package->fullPackageString())->toBe('vendor/missing:^9.0')
+            ->and($exception->getPrevious())->toBeInstanceOf(ComposerCommandException::class);
+
+        return;
+    }
+
+    $this->fail('Expected PackageNotFoundException to be thrown.');
+});
+
+test('it reports a missing dependency instead of the requested package', function () {
+    ComposerRunner::fake(fn (array $command): ProcessResult => new ProcessResult(
+        1,
+        'vendor/package 1.0.0 requires dependency/missing * -> could not be found in any version, there may be a typo in the package name.',
+    ));
+
+    try {
+        ComposerRunner::require('vendor/package:^1.0', '/tmp/example');
+    } catch (PackageNotFoundException $exception) {
+        expect($exception->package->fullPackageString())->toBe('dependency/missing');
+
+        return;
+    }
+
+    $this->fail('Expected PackageNotFoundException to be thrown.');
+});
+
+test('it preserves other composer require failures', function (string $diagnostic) {
+    ComposerRunner::fake(fn (array $command): ProcessResult => new ProcessResult(1, $diagnostic));
+
+    ComposerRunner::require('vendor/package:^9.0', '/tmp/example');
+})->with([
+    'constraint mismatch' => ['Root composer.json requires vendor/package ^9.0, found vendor/package[1.0.0] but it does not match the constraint.'],
+    'platform mismatch' => ['Package vendor/package has requirements incompatible with your PHP version, PHP extensions and Composer version.'],
+    'transport failure' => ['curl error 60: SSL certificate problem'],
+    'authentication failure' => ['Invalid credentials for https://repo.example.test/packages.json'],
+    'unknown failure' => ['Composer encountered an unexpected error.'],
+])->throws(ComposerCommandException::class, 'Composer command failed: require vendor/package:^9.0');
+
+test('generic composer commands do not classify missing-package output', function () {
+    ComposerRunner::fake(fn (array $command): ProcessResult => new ProcessResult(1, 'Could not find a matching version of package vendor/missing.'));
+
+    ComposerRunner::run(['update'], '/tmp/example');
+})->throws(ComposerCommandException::class, 'Composer command failed: update');
+
+test('it identifies a real composer missing-package diagnostic', function () {
+    $this->useIsolatedComposerHome();
+    $staging = $this->stagingWithPathPackages(['cpx-fixture/available']);
+
+    ProcessRunner::withLogger(
+        new SilentLogger,
+        fn () => ComposerRunner::require('cpx-fixture/missing:*', $staging),
+    );
+})->throws(PackageNotFoundException::class);
+
+test('it identifies a real missing transitive dependency', function () {
+    $this->useIsolatedComposerHome();
+
+    $fixture = $this->temporaryDirectory('cpx-fixture');
+    file_put_contents("{$fixture}/composer.json", json_encode([
+        'name' => 'cpx-fixture/parent',
+        'version' => '1.0.0',
+        'require' => ['cpx-fixture/missing' => '*'],
+    ], JSON_THROW_ON_ERROR));
+
+    $staging = $this->temporaryDirectory('cpx-staging');
+    file_put_contents("{$staging}/composer.json", json_encode([
+        'repositories' => [
+            ['type' => 'path', 'url' => $fixture, 'options' => ['symlink' => false]],
+            ['packagist.org' => false],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    try {
+        ProcessRunner::withLogger(
+            new SilentLogger,
+            fn () => ComposerRunner::require('cpx-fixture/parent:*', $staging),
+        );
+    } catch (PackageNotFoundException $exception) {
+        expect($exception->package->fullPackageString())->toBe('cpx-fixture/missing');
+
+        return;
+    }
+
+    $this->fail('Expected PackageNotFoundException to be thrown.');
+});
+
+test('it does not classify a real composer constraint failure as a missing package', function () {
+    $this->useIsolatedComposerHome();
+    $staging = $this->stagingWithPathPackages(['cpx-fixture/available']);
+
+    ComposerRunner::require('cpx-fixture/available:^2.0', $staging);
+})->throws(ComposerCommandException::class, 'Composer command failed: require cpx-fixture/available:^2.0');
 
 test('it reads the locked version of the requested package by name', function () {
     $directory = $this->temporaryDirectory('cpx-lock');

--- a/tests/Unit/ProcessRunnerTest.php
+++ b/tests/Unit/ProcessRunnerTest.php
@@ -2,6 +2,7 @@
 
 use Cpx\Process\ProcessRunner;
 use Cpx\Support\Interactivity;
+use Laravel\Prompts\Support\Logger;
 use Symfony\Component\Process\Process;
 
 test('it returns the child exit code when using inherited stdio', function () {
@@ -11,6 +12,38 @@ test('it returns the child exit code when using inherited stdio', function () {
     writeExecutable($binary, "#!/usr/bin/env php\n<?php exit(37);\n");
 
     expect((new ProcessRunner)->run([PHP_BINARY, $binary]))->toBe(37);
+});
+
+test('it captures child output and forwards it to the configured logger', function () {
+    $directory = $this->temporaryDirectory('cpx-process');
+    $binary = "{$directory}/output";
+
+    writeExecutable($binary, "#!/usr/bin/env php\n<?php fwrite(STDERR, 'composer diagnostic'); exit(23);\n");
+
+    $logger = new class extends Logger
+    {
+        /** @var list<string> */
+        public array $lines = [];
+
+        public function __construct()
+        {
+            parent::__construct('test');
+        }
+
+        public function line(string $message): void
+        {
+            $this->lines[] = $message;
+        }
+    };
+
+    $result = ProcessRunner::withLogger(
+        $logger,
+        fn () => (new ProcessRunner)->runWithOutput([PHP_BINARY, $binary]),
+    );
+
+    expect($result->exitCode)->toBe(23)
+        ->and($result->output)->toBe('composer diagnostic')
+        ->and($logger->lines)->toBe(['composer diagnostic']);
 });
 
 test('it forwards explicit environment variables to the child process', function () {


### PR DESCRIPTION
## Helpers

Adds `ProcessRunner::runWithOutput()`, which returns a `ProcessResult` containing the process exit code and captured output while preserving existing output forwarding.

Adds `ComposerRunner::require()`, which inspects Composer's output and throws `PackageNotFoundException` only for confirmed missing-package diagnostics. Other failures continue to throw `ComposerCommandException`.

## Fix

Package installation now uses this specialized method, preventing constraint, platform, authentication, and network errors from being mislabeled as "Package not found."