### PR TITLE
Fix global flag routing and clean, update, and gist behaviors

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -113,7 +113,7 @@ class Application extends SymfonyApplication
         $command = $input->getRawTokens()[0] ?? null;
 
         return is_string($command)
-            && ! in_array($command, ['--version', '-v'], true)
+            && ! str_starts_with($command, '-')
             && ! $this->has($command);
     }
 }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -56,10 +56,11 @@ class CleanCommand extends Command
         }
 
         [$mode, $timeLimit] = $this->resolve($input, $days);
+        $explicitDays = $days !== null;
 
         if ($json) {
             $result = Metadata::transaction(
-                fn (Metadata $metadata): CleanResult => $this->clean($metadata, $mode, $timeLimit, new SilentLogger),
+                fn (Metadata $metadata): CleanResult => $this->clean($metadata, $mode, $timeLimit, $explicitDays, new SilentLogger),
             );
 
             return $result->hasFailures()
@@ -70,7 +71,7 @@ class CleanCommand extends Command
         $result = task(
             label: 'Cleaning cpx caches',
             callback: fn (Logger $logger): CleanResult => Metadata::transaction(
-                fn (Metadata $metadata): CleanResult => $this->clean($metadata, $mode, $timeLimit, $logger),
+                fn (Metadata $metadata): CleanResult => $this->clean($metadata, $mode, $timeLimit, $explicitDays, $logger),
             ),
         );
 
@@ -85,8 +86,8 @@ class CleanCommand extends Command
     private function resolve(InputInterface $input, ?int $days): array
     {
         return match (true) {
-            $input->getOption('all') === true => [CleanMode::All, $this->timeLimitForDays(self::DEFAULT_DAYS)],
-            $input->getOption('sandbox') === true => [CleanMode::Sandbox, $this->timeLimitForDays(self::DEFAULT_DAYS)],
+            $input->getOption('all') === true => [CleanMode::All, $this->timeLimitForDays($days ?? self::DEFAULT_DAYS)],
+            $input->getOption('sandbox') === true => [CleanMode::Sandbox, $this->timeLimitForDays($days ?? self::DEFAULT_DAYS)],
             $days !== null => [CleanMode::Period, $this->timeLimitForDays($days)],
             default => $this->promptForMode(),
         };
@@ -142,16 +143,16 @@ class CleanCommand extends Command
         );
     }
 
-    private function clean(Metadata $metadata, CleanMode $mode, int $timeLimit, Logger $logger): CleanResult
+    private function clean(Metadata $metadata, CleanMode $mode, int $timeLimit, bool $explicitDays, Logger $logger): CleanResult
     {
         $result = new CleanResult;
 
         if ($mode->cleansPackages()) {
-            $this->removeStalePackages($metadata, $mode->removesAllPackages(), $timeLimit, $result, $logger);
+            $this->removeStalePackages($metadata, ! $explicitDays && $mode->removesAllPackages(), $timeLimit, $result, $logger);
             $this->removeOrphanPackages($metadata, $result, $logger);
         }
 
-        $this->removeStaleSandboxes($metadata, $mode->removesAllSandboxes(), $timeLimit, $result, $logger);
+        $this->removeStaleSandboxes($metadata, ! $explicitDays && $mode->removesAllSandboxes(), $timeLimit, $result, $logger);
         $this->removeOrphanSandboxes($metadata, $result, $logger);
 
         return $result;

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -139,14 +139,14 @@ class ExecCommand extends Command
         return $file;
     }
 
-    /** @return (Closure(GistFile...): GistFile)|null */
+    /** @return (Closure(list<GistFile>): GistFile)|null */
     private function chooseGistFile(InputInterface $input): ?Closure
     {
         if (! $input->isInteractive()) {
             return null;
         }
 
-        return function (GistFile ...$files): GistFile {
+        return function (array $files): GistFile {
             $files = array_values($files);
 
             try {

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -58,8 +58,8 @@ class UpdateCommand extends Command
         try {
             match (true) {
                 str_contains($target, '/') => $this->updatePackage(Package::parse($target)),
-                $target !== '' => $this->updateVendor($target),
-                default => $this->updateAllPackages(),
+                $target !== '' => $this->updateMatching("{$target}/*/*", "There are no packages in vendor '{$target}' to update."),
+                default => $this->updateMatching('*/*/*', 'There are no packages to update.'),
             };
         } catch (InvalidArgumentException $exception) {
             return Result::failure($output, $exception->getMessage());
@@ -87,55 +87,13 @@ class UpdateCommand extends Command
         return self::FAILURE;
     }
 
-    protected function updateAllPackages(): void
-    {
-        $packageDirectories = glob(cpx_path('*/*/*'), GLOB_ONLYDIR) ?: [];
-
-        if (empty($packageDirectories)) {
-            if (! $this->json) {
-                info('There are no packages to update.');
-            }
-        } else {
-            foreach ($packageDirectories as $directory) {
-                $this->updateDirectory($directory);
-            }
-        }
-    }
-
-    protected function updateVendor(string $vendor): void
-    {
-        $packageDirectories = glob(cpx_path("{$vendor}/*/*"), GLOB_ONLYDIR) ?: [];
-
-        if (empty($packageDirectories)) {
-            if (! $this->json) {
-                info("There are no packages in vendor '{$vendor}' to update.");
-            }
-        } else {
-            foreach ($packageDirectories as $directory) {
-                $this->updateDirectory($directory);
-            }
-        }
-    }
-
     protected function updatePackage(Package $package): void
     {
-        if ($package->version) {
-            $this->updateDirectory(cpx_path($package->folder()));
+        $pattern = $package->version === null
+            ? "{$package->vendor}/{$package->name}/*"
+            : $package->folder();
 
-            return;
-        }
-
-        $packageDirectories = glob(cpx_path("{$package->vendor}/{$package->name}/*"), GLOB_ONLYDIR) ?: [];
-
-        if (empty($packageDirectories)) {
-            if (! $this->json) {
-                info("There are no installed versions of '{$package->vendor}/{$package->name}' to update.");
-            }
-        } else {
-            foreach ($packageDirectories as $directory) {
-                $this->updateDirectory($directory);
-            }
-        }
+        $this->updateMatching($pattern, "There are no installed versions of '{$package->fullPackageString()}' to update.");
     }
 
     protected function updateDirectory(string $directory): void
@@ -167,6 +125,23 @@ class UpdateCommand extends Command
             },
             keepSummary: true,
         );
+    }
+
+    private function updateMatching(string $pattern, string $emptyMessage): void
+    {
+        $directories = glob(cpx_path($pattern), GLOB_ONLYDIR) ?: [];
+
+        if ($directories === []) {
+            if (! $this->json) {
+                info($emptyMessage);
+            }
+
+            return;
+        }
+
+        foreach ($directories as $directory) {
+            $this->updateDirectory($directory);
+        }
     }
 
     /** @return array{from: string, to: string, error: string|null} */

--- a/src/Gists/Gist.php
+++ b/src/Gists/Gist.php
@@ -60,7 +60,7 @@ readonly class Gist
     }
 
     /**
-     * @param  (Closure(GistFile...): GistFile)|null  $choose
+     * @param  (Closure(list<GistFile>): GistFile)|null  $choose
      *
      * @throws GistException
      */
@@ -85,7 +85,7 @@ readonly class Gist
         }
 
         if ($choose !== null) {
-            return $choose(...$phpFiles);
+            return $choose($phpFiles);
         }
 
         throw GistException::ambiguousPhpFiles($phpFiles);

--- a/src/Gists/GistClient.php
+++ b/src/Gists/GistClient.php
@@ -17,7 +17,7 @@ class GistClient
     }
 
     /**
-     * @param  (Closure(GistFile...): GistFile)|null  $chooseFile
+     * @param  (Closure(list<GistFile>): GistFile)|null  $chooseFile
      *
      * @throws GistException
      */
@@ -58,7 +58,7 @@ class GistClient
     }
 
     /**
-     * @param  callable(GistUrl, (Closure(GistFile...): GistFile)|null): GistFile  $fetcher
+     * @param  callable(GistUrl, (Closure(list<GistFile>): GistFile)|null): GistFile  $fetcher
      */
     public static function fake(callable $fetcher): void
     {

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -95,6 +95,101 @@ test('the sandbox option removes exec caches but preserves package caches', func
         ->and(Metadata::open()->execCache)->toBe([]);
 });
 
+test('the sandbox option with a days window removes only sandboxes older than the window', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    $oldSandbox = cpx_path('.exec_cache/old-sandbox');
+    $freshSandbox = cpx_path('.exec_cache/fresh-sandbox');
+    mkdir($oldSandbox, 0755, true);
+    mkdir($freshSandbox, 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => '2024-01-01 00:00:00', 'last_run' => '2024-01-01 00:00:00'],
+        ],
+        'execCache' => [
+            'old-sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time() - 100 * 86400, 'last_run' => time() - 100 * 86400],
+            'fresh-sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--sandbox', '--days=90']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($oldSandbox))->toBeFalse()
+        ->and(is_dir($freshSandbox))->toBeTrue()
+        ->and(is_dir($packageDirectory))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeTrue()
+        ->and(array_keys(Metadata::open()->execCache))->toBe(['fresh-sandbox']);
+});
+
+test('the all option with a days window applies it to packages and sandboxes', function () {
+    $this->useIsolatedComposerHome();
+
+    $oldPackage = cpx_path('laravel/pint/latest');
+    $freshPackage = cpx_path('phpunit/phpunit/latest');
+    mkdir($oldPackage.'/vendor', 0755, true);
+    file_put_contents($oldPackage.'/vendor/autoload.php', '<?php');
+    mkdir($freshPackage.'/vendor', 0755, true);
+    file_put_contents($freshPackage.'/vendor/autoload.php', '<?php');
+
+    $oldSandbox = cpx_path('.exec_cache/old-sandbox');
+    $freshSandbox = cpx_path('.exec_cache/fresh-sandbox');
+    mkdir($oldSandbox, 0755, true);
+    mkdir($freshSandbox, 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => date('Y-m-d H:i:s', time() - 10 * 86400), 'last_run' => date('Y-m-d H:i:s', time() - 10 * 86400)],
+            'phpunit/phpunit' => ['last_updated' => date('Y-m-d H:i:s'), 'last_run' => date('Y-m-d H:i:s')],
+        ],
+        'execCache' => [
+            'old-sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time() - 10 * 86400, 'last_run' => time() - 10 * 86400],
+            'fresh-sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--all', '--days=7']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($oldPackage))->toBeFalse()
+        ->and(is_dir($freshPackage))->toBeTrue()
+        ->and(is_dir($oldSandbox))->toBeFalse()
+        ->and(is_dir($freshSandbox))->toBeTrue()
+        ->and(Metadata::open()->hasPackage('laravel/pint'))->toBeFalse()
+        ->and(Metadata::open()->hasPackage('phpunit/phpunit'))->toBeTrue();
+});
+
+test('the all option without a days window still removes fresh caches', function () {
+    $this->useIsolatedComposerHome();
+
+    $packageDirectory = cpx_path('laravel/pint/latest');
+    mkdir($packageDirectory.'/vendor', 0755, true);
+    file_put_contents($packageDirectory.'/vendor/autoload.php', '<?php');
+
+    $sandboxDirectory = cpx_path('.exec_cache/sandbox');
+    mkdir($sandboxDirectory, 0755, true);
+
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => date('Y-m-d H:i:s'), 'last_run' => date('Y-m-d H:i:s')],
+        ],
+        'execCache' => [
+            'sandbox' => ['packages' => ['laravel/pint'], 'last_updated' => time(), 'last_run' => time()],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    [$status] = runCpxCommand(['clean', '--all']);
+
+    expect($status)->toBe(0)
+        ->and(is_dir($packageDirectory))->toBeFalse()
+        ->and(is_dir($sandboxDirectory))->toBeFalse();
+});
+
 test('the sandbox option is a no-op when there are no sandboxes', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -297,6 +297,38 @@ test('package-target version options are forwarded instead of rendering cpx vers
         ->and($output->fetch())->not->toContain('cpx version:');
 });
 
+test('the global help flag renders Symfony help', function () {
+    [$status, $output] = runCpxCommand(['--help']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Usage:')
+        ->and($output)->not->toContain('Unrecognised command');
+});
+
+test('the short help flag renders Symfony help', function () {
+    [$status, $output] = runCpxCommand(['-h']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Usage:')
+        ->and($output)->not->toContain('Unrecognised command');
+});
+
+test('the short version flag prints the cpx version', function () {
+    [$status, $output] = runCpxCommand(['-V']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('cpx dev')
+        ->and($output)->not->toContain('Unrecognised command');
+});
+
+test('the version flag prints the cpx version', function () {
+    [$status, $output] = runCpxCommand(['--version']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('cpx dev')
+        ->and($output)->not->toContain('Unrecognised command');
+});
+
 test('package-looking values with shell metacharacters fail before composer execution', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -163,6 +163,55 @@ test('update requests a composer update for each installed package directory', f
         ->and($calls[0])->toContain('--working-dir='.cpx_path('laravel/pint/latest'));
 });
 
+test('update reports when a versioned package was never installed', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls);
+
+    [$status, $output] = runCpxCommand(['update', 'vendor/pkg:^2']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain("There are no installed versions of 'vendor/pkg:^2' to update.")
+        ->and($calls)->toBe([]);
+});
+
+test('update with a package target updates only that package', function () {
+    $this->useIsolatedComposerHome();
+
+    prepareCachedPackage('laravel/pint', ['pint']);
+    prepareCachedPackage('vendor/other', ['other']);
+
+    $calls = [];
+    fakeComposer($calls);
+
+    [$status, $output] = runCpxCommand(['update', 'laravel/pint']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Updating laravel/pint/latest')
+        ->and($output)->not->toContain('vendor/other')
+        ->and($calls)->toHaveCount(1)
+        ->and($calls[0])->toContain('--working-dir='.cpx_path('laravel/pint/latest'));
+});
+
+test('update with a vendor target updates only that vendor', function () {
+    $this->useIsolatedComposerHome();
+
+    prepareCachedPackage('laravel/pint', ['pint']);
+    prepareCachedPackage('vendor/other', ['other']);
+
+    $calls = [];
+    fakeComposer($calls);
+
+    [$status, $output] = runCpxCommand(['update', 'laravel']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Updating laravel/pint/latest')
+        ->and($output)->not->toContain('vendor/other')
+        ->and($calls)->toHaveCount(1)
+        ->and($calls[0])->toContain('--working-dir='.cpx_path('laravel/pint/latest'));
+});
+
 test('update continues past a failing package and summarizes the failure', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/ExecGistTest.php
+++ b/tests/Feature/ExecGistTest.php
@@ -134,10 +134,10 @@ test('exec prompts for the file of a multi-php gist', function () {
 
     Prompt::fake([Key::DOWN, Key::ENTER]);
 
-    GistClient::fake(fn (GistUrl $url, ?Closure $choose): GistFile => $choose(
+    GistClient::fake(fn (GistUrl $url, ?Closure $choose): GistFile => $choose([
         new GistFile(filename: 'first.php', language: 'PHP', content: '<?php file_put_contents('.var_export($marker, true).', "first");'),
         new GistFile(filename: 'second.php', language: 'PHP', content: '<?php file_put_contents('.var_export($marker, true).', "second");'),
-    ));
+    ]));
 
     [$status, $output] = runCpxCommand(['exec', GIST_URL]);
 
@@ -150,10 +150,10 @@ test('exec falls back to the ambiguous files callout when the terminal cannot pr
     $directory = $this->temporaryDirectory('cpx-exec-gist');
     $this->useWorkingDirectory($directory);
 
-    GistClient::fake(fn (GistUrl $url, ?Closure $choose): GistFile => $choose(
+    GistClient::fake(fn (GistUrl $url, ?Closure $choose): GistFile => $choose([
         new GistFile(filename: 'first.php', language: 'PHP', content: '<?php'),
         new GistFile(filename: 'second.php', language: 'PHP', content: '<?php'),
-    ));
+    ]));
 
     [$status, $output] = runCpxCommand(['exec', GIST_URL]);
 

--- a/tests/Unit/GistClientTest.php
+++ b/tests/Unit/GistClientTest.php
@@ -75,7 +75,7 @@ test('passes the chooser through to file selection', function () {
         ], JSON_THROW_ON_ERROR),
     ]);
 
-    $file = $client->fetchFile(gistUrl(), fn (GistFile ...$files): GistFile => $files[1]);
+    $file = $client->fetchFile(gistUrl(), fn (array $files): GistFile => $files[1]);
 
     expect($file->filename)->toBe('second.php');
 });

--- a/tests/Unit/GistTest.php
+++ b/tests/Unit/GistTest.php
@@ -152,7 +152,7 @@ test('select asks the chooser when multiple php files qualify', function () {
 
     $offered = null;
 
-    $file = $gist->select(null, function (GistFile ...$files) use (&$offered): GistFile {
+    $file = $gist->select(null, function (array $files) use (&$offered): GistFile {
         $offered = array_map(fn (GistFile $file): string => $file->filename, $files);
 
         return $files[1];


### PR DESCRIPTION
## Overview

A few commands misbehave in specific flows: the global `--help`/`-h`/`-V` flags get hijacked by the package fallback and trigger a package install instead of showing help, `clean --all` and `clean --sandbox` ignore an explicit `--days` window, `update` runs Composer against versioned targets that were never installed, and the gist file chooser receives its options keyed by filename instead of as a list.

## Solution

Bare global flags are now routed to the Symfony console before the package fallback kicks in, all clean modes honor an explicitly passed `--days` window, the update paths are consolidated so never-installed versioned targets are reported instead of failing against a missing directory, and gist files are handed to the chooser as a list. Each fix comes with tests covering the previously broken behavior.