### PR TITLE
Skip broken alias and metadata entries instead of crashing

### DIFF
--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -9,6 +9,7 @@ use Cpx\Packages\Package;
 use Cpx\Support\Arr;
 use Cpx\Support\Filesystem;
 use Cpx\Support\Lock;
+use InvalidArgumentException;
 
 class Metadata
 {
@@ -53,9 +54,15 @@ class Metadata
                         return [];
                     }
 
+                    try {
+                        $package = Package::parse($key);
+                    } catch (InvalidArgumentException) {
+                        return [];
+                    }
+
                     return [
                         $key => new PackageMetadata(
-                            package: Package::parse($key),
+                            package: $package,
                             lastUpdatedAt: self::normalizeTimestamp($value['last_updated'] ?? null),
                             lastRunAt: self::normalizeTimestamp($value['last_run'] ?? null),
                         ),

--- a/src/Cache/Metadata.php
+++ b/src/Cache/Metadata.php
@@ -49,7 +49,7 @@ class Metadata
 
         return new self(
             packages: Arr::mapWithKeys(
-                function (string $key, mixed $value): array {
+                function (mixed $value, string $key): array {
                     if (! is_array($value)) {
                         return [];
                     }
@@ -71,7 +71,7 @@ class Metadata
                 is_array($json['packages'] ?? null) ? $json['packages'] : [],
             ),
             execCache: Arr::mapWithKeys(
-                function (string $key, mixed $value): array {
+                function (mixed $value, string $key): array {
                     if (! is_array($value)) {
                         return [];
                     }
@@ -142,7 +142,7 @@ class Metadata
         return [
             'version' => self::VERSION,
             'packages' => Arr::mapWithKeys(
-                fn (string $key, PackageMetadata $packageMetadata): array => [
+                fn (PackageMetadata $packageMetadata): array => [
                     $packageMetadata->package->fullPackageString() => [
                         'last_updated' => $packageMetadata->lastUpdatedAt,
                         'last_run' => $packageMetadata->lastRunAt,
@@ -151,7 +151,7 @@ class Metadata
                 $this->packages,
             ),
             'execCache' => Arr::mapWithKeys(
-                fn (string $key, ExecSandboxMetadata $sandbox): array => [
+                fn (ExecSandboxMetadata $sandbox): array => [
                     $sandbox->key => [
                         'packages' => $sandbox->packages,
                         'last_updated' => $sandbox->lastUpdatedAt,

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -123,7 +123,7 @@ class Package
     {
         $binScripts = ComposerRunner::detectBinFromComposer($this->packagePath($installDir));
 
-        return Arr::mapWithKeys(fn (int $_, string $value): array => [basename($value) => $value], $binScripts);
+        return Arr::mapWithKeys(fn (string $value): array => [basename($value) => $value], $binScripts);
     }
 
     public function delete(): void

--- a/src/Packages/UserAliases.php
+++ b/src/Packages/UserAliases.php
@@ -6,6 +6,10 @@ namespace Cpx\Packages;
 
 use Cpx\Exceptions\MalformedAliasesException;
 use Cpx\Support\Filesystem;
+use Cpx\Support\Interactivity;
+use InvalidArgumentException;
+
+use function Laravel\Prompts\warning;
 
 class UserAliases
 {
@@ -13,9 +17,11 @@ class UserAliases
 
     /**
      * @param  array<string, Package>  $aliases
+     * @param  array<string, mixed>  $broken
      */
     protected function __construct(
         protected array $aliases = [],
+        protected array $broken = [],
     ) {
         //
     }
@@ -38,25 +44,21 @@ class UserAliases
         }
 
         $aliases = [];
+        $broken = [];
 
         foreach ($json as $name => $value) {
-            if (! is_string($name) || ! is_array($value)) {
-                throw new MalformedAliasesException($file);
+            try {
+                $aliases[(string) $name] = self::parseEntry($file, $name, $value);
+            } catch (MalformedAliasesException|InvalidArgumentException) {
+                $broken[(string) $name] = $value;
             }
-
-            $package = $value['package'] ?? null;
-            $bin = $value['bin'] ?? null;
-
-            if (! is_string($package) || (! is_string($bin) && $bin !== null)) {
-                throw new MalformedAliasesException($file);
-            }
-
-            $aliases[$name] = (LocalPackage::supports($package)
-                ? LocalPackage::parse($package)
-                : Package::parse($package))->withBin($bin);
         }
 
-        return new self($aliases);
+        if ($broken !== [] && Interactivity::isInteractive()) {
+            warning('Skipped aliases that could not be loaded: '.implode(', ', array_keys($broken)).'. Remove them with `cpx unalias <name>`.');
+        }
+
+        return new self($aliases, $broken);
     }
 
     /** @return array<string, Package> */
@@ -67,7 +69,7 @@ class UserAliases
 
     public function has(string $name): bool
     {
-        return array_key_exists($name, $this->aliases);
+        return array_key_exists($name, $this->aliases) || array_key_exists($name, $this->broken);
     }
 
     public function find(string $name): ?Package
@@ -78,20 +80,22 @@ class UserAliases
     public function put(string $name, Package $package): self
     {
         $this->aliases[$name] = $package;
+        unset($this->broken[$name]);
 
         return $this;
     }
 
     public function remove(string $name): self
     {
-        unset($this->aliases[$name]);
+        unset($this->aliases[$name], $this->broken[$name]);
 
         return $this;
     }
 
     public function save(): void
     {
-        Filesystem::writeAtomic(cpx_path(self::FILE), (string) json_encode($this->toArray(), JSON_PRETTY_PRINT));
+        // Broken entries stay in the file untouched until removed with `unalias`.
+        Filesystem::writeAtomic(cpx_path(self::FILE), (string) json_encode($this->toArray() + $this->broken, JSON_PRETTY_PRINT));
     }
 
     /** @return array<string, array{package: string, bin: string|null}> */
@@ -104,5 +108,27 @@ class UserAliases
             ],
             $this->aliases,
         );
+    }
+
+    /**
+     * @throws MalformedAliasesException
+     * @throws InvalidArgumentException
+     */
+    private static function parseEntry(string $file, int|string $name, mixed $value): Package
+    {
+        if (! is_string($name) || ! is_array($value)) {
+            throw new MalformedAliasesException($file);
+        }
+
+        $package = $value['package'] ?? null;
+        $bin = $value['bin'] ?? null;
+
+        if (! is_string($package) || (! is_string($bin) && $bin !== null)) {
+            throw new MalformedAliasesException($file);
+        }
+
+        return (LocalPackage::supports($package)
+            ? LocalPackage::parse($package)
+            : Package::parse($package))->withBin($bin);
     }
 }

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -12,7 +12,7 @@ class Arr
      * @template TReturnKey of array-key
      * @template TReturnValue
      *
-     * @param  callable(TKey, TValue): array<TReturnKey, TReturnValue>  $callback
+     * @param  callable(TValue, TKey): array<TReturnKey, TReturnValue>  $callback
      * @param  array<TKey, TValue>  $array
      * @return array<TReturnKey, TReturnValue>
      */
@@ -21,7 +21,9 @@ class Arr
         $result = [];
 
         foreach ($array as $key => $value) {
-            $result += $callback($key, $value);
+            foreach ($callback($value, $key) as $mappedKey => $mappedValue) {
+                $result[$mappedKey] = $mappedValue;
+            }
         }
 
         return $result;

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -3,10 +3,12 @@
 use Cpx\Application;
 use Cpx\Composer\ComposerRunner;
 use Cpx\Input\PackageInvocation;
+use Cpx\Packages\LocalPackage;
 use Cpx\Packages\Package;
 use Cpx\Packages\PackageCommandRunner;
 use Cpx\Packages\UserAliases;
 use Cpx\Process\ProcessResult;
+use Cpx\Support\Filesystem;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -99,6 +101,43 @@ test('aliases lists user-defined aliases', function () {
         ->and($output)->toContain('Your aliases:')
         ->and($output)->toContain('cpx mypint')
         ->and($output)->toContain('laravel/pint');
+});
+
+test('aliases lists healthy aliases and warns about broken ones', function () {
+    $this->useIsolatedComposerHome();
+
+    $root = $this->prepareLocalPackage(name: 'vendor/stale');
+    UserAliases::open()
+        ->put('mypint', Package::parse('laravel/pint'))
+        ->put('stale', LocalPackage::parse($root))
+        ->save();
+    Filesystem::deleteDirectory($root);
+
+    [$status, $output] = runCpxCommand(['aliases']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Your aliases:')
+        ->and($output)->toContain('laravel/pint')
+        ->and($output)->toContain('Skipped aliases that could not be loaded: stale');
+});
+
+test('unalias removes a broken alias', function () {
+    $this->useIsolatedComposerHome();
+
+    $root = $this->prepareLocalPackage(name: 'vendor/stale');
+    UserAliases::open()
+        ->put('mypint', Package::parse('laravel/pint'))
+        ->put('stale', LocalPackage::parse($root))
+        ->save();
+    Filesystem::deleteDirectory($root);
+
+    [$status, $output] = runCpxCommand(['unalias', 'stale']);
+    $aliases = UserAliases::open();
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('Alias "stale" removed.')
+        ->and($aliases->has('stale'))->toBeFalse()
+        ->and($aliases->has('mypint'))->toBeTrue();
 });
 
 test('a user-defined alias resolves to its package', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -22,6 +22,20 @@ function runCpxCommand(array $arguments): array
     return [$status, $output->fetch()];
 }
 
+/**
+ * @param  array<string, mixed>  $aliases
+ */
+function writeAliasesFile(array $aliases): void
+{
+    $file = cpx_path('aliases.json');
+
+    if (! is_dir(dirname($file))) {
+        mkdir(dirname($file), 0755, true);
+    }
+
+    file_put_contents($file, json_encode($aliases, JSON_THROW_ON_ERROR));
+}
+
 function writeExecutable(string $path, string $contents): void
 {
     file_put_contents($path, $contents);

--- a/tests/Unit/ArrTest.php
+++ b/tests/Unit/ArrTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Cpx\Support\Arr;
+
+test('mapWithKeys passes the value first and the key second', function () {
+    $result = Arr::mapWithKeys(
+        fn (string $value, int $key): array => ["{$key}-{$value}" => $value],
+        ['a', 'b'],
+    );
+
+    expect($result)->toBe(['0-a' => 'a', '1-b' => 'b']);
+});
+
+test('mapWithKeys lets later keys win on collision', function () {
+    $result = Arr::mapWithKeys(
+        fn (string $value): array => ['key' => $value],
+        ['first', 'second'],
+    );
+
+    expect($result)->toBe(['key' => 'second']);
+});

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -86,6 +86,44 @@ test('it loads a legacy metadata file without a version section', function () {
         ->and($metadata->execCache['sandbox']->lastRunAt)->toBe(1);
 });
 
+test('it drops packages with unparseable keys and keeps valid entries', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => 1, 'last_run' => 1],
+            'Not A Package!!' => ['last_updated' => 1, 'last_run' => 1],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    $metadata = Metadata::open();
+
+    expect($metadata->hasPackage('laravel/pint'))->toBeTrue()
+        ->and($metadata->hasPackage('Not A Package!!'))->toBeFalse();
+});
+
+test('a write after opening persists the healed package state', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(dirname(cpx_path('.cpx_metadata.json')), 0755, true);
+    file_put_contents(cpx_path('.cpx_metadata.json'), json_encode([
+        'packages' => [
+            'laravel/pint' => ['last_updated' => 1, 'last_run' => 1],
+            'Not A Package!!' => ['last_updated' => 1, 'last_run' => 1],
+        ],
+        'execCache' => [],
+    ], JSON_THROW_ON_ERROR));
+
+    Metadata::transaction(fn (Metadata $metadata) => $metadata->recordRun(Package::parse('laravel/pint')));
+
+    $decoded = json_decode((string) file_get_contents(cpx_path('.cpx_metadata.json')), true);
+
+    expect($decoded['packages'])->toHaveKey('laravel/pint')
+        ->and($decoded['packages'])->not->toHaveKey('Not A Package!!');
+});
+
 test('interleaved transactions keep every update and leave valid json', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Unit/UserAliasesTest.php
+++ b/tests/Unit/UserAliasesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cpx\Exceptions\MalformedAliasesException;
 use Cpx\Packages\Package;
 use Cpx\Packages\UserAliases;
 
@@ -59,3 +60,94 @@ test('removing an unknown alias is a no-op', function () {
 
     expect(UserAliases::open()->has('mypint'))->toBeTrue();
 });
+
+test('it skips aliases whose package fails to parse and keeps healthy ones', function () {
+    $this->useIsolatedComposerHome();
+
+    writeAliasesFile([
+        'good' => ['package' => 'laravel/pint', 'bin' => null],
+        'broken' => ['package' => 'Not A Package!!', 'bin' => null],
+    ]);
+
+    $aliases = UserAliases::open();
+
+    expect($aliases->find('good')?->fullPackageString())->toBe('laravel/pint')
+        ->and($aliases->find('broken'))->toBeNull()
+        ->and($aliases->all())->not->toHaveKey('broken');
+});
+
+test('it skips local-path aliases whose directory no longer exists', function () {
+    $this->useIsolatedComposerHome();
+
+    $root = $this->temporaryDirectory('cpx-stale-alias');
+    rmdir($root);
+
+    writeAliasesFile([
+        'good' => ['package' => 'laravel/pint', 'bin' => null],
+        'stale' => ['package' => $root, 'bin' => null],
+    ]);
+
+    $aliases = UserAliases::open();
+
+    expect($aliases->find('good')?->fullPackageString())->toBe('laravel/pint')
+        ->and($aliases->find('stale'))->toBeNull();
+});
+
+test('it skips malformed alias entries without throwing', function () {
+    $this->useIsolatedComposerHome();
+
+    writeAliasesFile([
+        'good' => ['package' => 'laravel/pint', 'bin' => null],
+        'notAnArray' => 'laravel/pint',
+        'badBin' => ['package' => 'laravel/pint', 'bin' => 123],
+        'noPackage' => ['bin' => 'tool'],
+    ]);
+
+    $aliases = UserAliases::open();
+
+    expect(array_keys($aliases->all()))->toBe(['good'])
+        ->and($aliases->find('good')?->fullPackageString())->toBe('laravel/pint');
+});
+
+test('broken aliases stay addressable and survive saves until removed', function () {
+    $this->useIsolatedComposerHome();
+
+    writeAliasesFile([
+        'good' => ['package' => 'laravel/pint', 'bin' => null],
+        'broken' => ['package' => 'Not A Package!!', 'bin' => null],
+    ]);
+
+    $aliases = UserAliases::open();
+    $aliases->save();
+
+    expect($aliases->has('broken'))->toBeTrue()
+        ->and(json_decode((string) file_get_contents(cpx_path('aliases.json')), true))
+        ->toHaveKey('broken');
+
+    UserAliases::open()->remove('broken')->save();
+    $healed = json_decode((string) file_get_contents(cpx_path('aliases.json')), true);
+
+    expect($healed)->not->toHaveKey('broken')
+        ->and($healed)->toHaveKey('good');
+});
+
+test('re-aliasing over a broken name replaces the broken entry', function () {
+    $this->useIsolatedComposerHome();
+
+    writeAliasesFile([
+        'broken' => ['package' => 'Not A Package!!', 'bin' => null],
+    ]);
+
+    UserAliases::open()->put('broken', Package::parse('laravel/pint'))->save();
+
+    expect(UserAliases::open()->find('broken')?->fullPackageString())->toBe('laravel/pint');
+});
+
+test('a fully malformed aliases file still throws', function () {
+    $this->useIsolatedComposerHome();
+
+    mkdir(dirname(cpx_path('aliases.json')), 0755, true);
+    file_put_contents(cpx_path('aliases.json'), '"just a string"');
+
+    UserAliases::open();
+})->throws(MalformedAliasesException::class);


### PR DESCRIPTION
## Overview

A single malformed entry in the aliases file or the metadata cache currently throws during loading, which crashes every cpx command until the file is fixed by hand.

## Solution

Both files are now parsed entry by entry: valid entries keep working, broken ones are skipped and reported with a warning that points to `cpx unalias <name>`, and broken aliases stay recognized by name so `unalias` can actually remove them. Alongside this, `Arr::mapWithKeys` is aligned with Laravel's value-first callback contract that the metadata parsing relies on, and the existing call sites are updated to match.