### PR TITLE
Share the package run and staged-install lifecycles

### DIFF
--- a/src/Packages/BinResolver.php
+++ b/src/Packages/BinResolver.php
@@ -23,23 +23,19 @@ class BinResolver
             return new ResolvedBin($bins[array_key_first($bins)], $invocation);
         }
 
-        $candidates = array_filter([
-            $invocation->target,
-            $invocation->firstForwardedToken(),
-            $packageName,
-        ]);
-
-        foreach (array_unique($candidates) as $candidate) {
+        foreach (array_unique([$invocation->target, $packageName]) as $candidate) {
             $command = self::match($bins, $candidate);
 
             if ($command !== null) {
-                return $invocation->firstForwardedToken() === $candidate
-                    ? new ResolvedBin($command, $invocation->withoutFirstForwardedToken())
-                    : new ResolvedBin($command, $invocation);
+                return new ResolvedBin($command, $invocation);
             }
         }
 
-        return null;
+        $forwarded = $invocation->firstForwardedToken();
+        $command = $forwarded === null ? null : self::match($bins, $forwarded);
+
+        // Only a forwarded-token match consumes the token; target and package-name matches keep it.
+        return $command === null ? null : new ResolvedBin($command, $invocation->withoutFirstForwardedToken());
     }
 
     /**

--- a/src/Packages/ExecSandbox.php
+++ b/src/Packages/ExecSandbox.php
@@ -7,12 +7,14 @@ namespace Cpx\Packages;
 use Cpx\Cache\ExecSandboxMetadata;
 use Cpx\Cache\Metadata;
 use Cpx\Composer\ComposerRunner;
+use Cpx\Exceptions\ComposerCommandException;
 use Cpx\Exceptions\ComposerInstallException;
 use Cpx\Runtime\PhpExecutionHelper;
-use Cpx\Support\Filesystem;
 use RuntimeException;
 use stdClass;
 use Throwable;
+
+use function Laravel\Prompts\warning;
 
 class ExecSandbox
 {
@@ -76,44 +78,27 @@ class ExecSandbox
 
     private function install(): int
     {
-        $cacheRoot = cpx_path();
-        Filesystem::ensureDirectory($cacheRoot);
-
-        $stagingDir = $this->path().'.installing.'.getmypid();
-        $this->stageInstall($stagingDir, $cacheRoot);
-
-        try {
-            Filesystem::replaceDirectory($stagingDir, $this->path());
-        } catch (RuntimeException $exception) {
-            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-
-            throw new ComposerInstallException("Unable to finalize the exec sandbox for {$this->key}; another process may be holding files under {$this->path()}.", previous: $exception);
-        }
+        StagedInstall::run(
+            targetDir: $this->path(),
+            scaffold: [
+                'require' => new stdClass,
+                'config' => [
+                    'vendor-dir' => './vendor',
+                ],
+            ],
+            install: function (string $stagingDir): void {
+                foreach ($this->packages as $package) {
+                    try {
+                        ComposerRunner::run(['require', $package], $stagingDir);
+                    } catch (Throwable $exception) {
+                        throw new ComposerInstallException("Failed to install package: {$package}.", previous: $exception);
+                    }
+                }
+            },
+            finalizeFailure: fn (RuntimeException $exception): Throwable => new ComposerInstallException("Unable to finalize the exec sandbox for {$this->key}; another process may be holding files under {$this->path()}.", previous: $exception),
+        );
 
         return time();
-    }
-
-    private function stageInstall(string $stagingDir, string $cacheRoot): void
-    {
-        Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-        Filesystem::ensureDirectory($stagingDir);
-
-        file_put_contents("{$stagingDir}/composer.json", json_encode([
-            'require' => new stdClass,
-            'config' => [
-                'vendor-dir' => './vendor',
-            ],
-        ], JSON_PRETTY_PRINT));
-
-        foreach ($this->packages as $package) {
-            try {
-                ComposerRunner::run(['require', $package], $stagingDir);
-            } catch (Throwable $exception) {
-                Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-
-                throw new ComposerInstallException("Failed to install package: {$package}.", previous: $exception);
-            }
-        }
     }
 
     private function update(): ?int
@@ -122,7 +107,10 @@ class ExecSandbox
             ComposerRunner::run(['update'], $this->path());
 
             return time();
-        } catch (Throwable) {
+        } catch (ComposerCommandException $exception) {
+            // Tolerate failed refreshes (offline, registry outage); the existing install keeps working.
+            warning("Could not update the exec sandbox: {$exception->getMessage()}");
+
             return null;
         }
     }

--- a/src/Packages/LocalPackage.php
+++ b/src/Packages/LocalPackage.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace Cpx\Packages;
 
-use Cpx\Input\PackageInvocation;
-use Cpx\Process\ProcessRunner;
+use BadMethodCallException;
 use Cpx\Support\Filesystem;
-use Cpx\Support\Result;
 use InvalidArgumentException;
 use JsonException;
-use RuntimeException;
-use Symfony\Component\Console\Output\OutputInterface;
-
-use function Laravel\Prompts\info;
 
 class LocalPackage extends Package
 {
@@ -95,7 +89,7 @@ class LocalPackage extends Package
         return new self(
             root: $root,
             name: self::packageName($composer, $root),
-            localBinaries: self::manifestBinaries($composer),
+            localBinaries: self::mapBinaries($composer['bin'] ?? []),
         );
     }
 
@@ -117,33 +111,34 @@ class LocalPackage extends Package
         return $this->root;
     }
 
-    public function runCommand(PackageInvocation $invocation, OutputInterface $output, bool $autoUpdate = true): int
+    public function packagePath(string $installDir): string
     {
-        if ($this->localBinaries === []) {
-            return Result::failure($output, "No bin command found in {$this->root}.");
-        }
+        return $this->root;
+    }
 
-        $resolved = BinResolver::resolve($this->localBinaries, $invocation, $this->name, $this->bin);
+    public function installPath(): string
+    {
+        throw self::noCacheLifecycle(__FUNCTION__);
+    }
 
-        if ($resolved === null && $this->bin !== null) {
-            throw new RuntimeException("The requested bin command '{$this->bin}' was not found in {$this}.");
-        }
+    public function delete(): void
+    {
+        throw self::noCacheLifecycle(__FUNCTION__);
+    }
 
-        $resolved ??= $this->chooseBinCommand($this->localBinaries, $invocation);
+    public function isInstalled(): bool
+    {
+        throw self::noCacheLifecycle(__FUNCTION__);
+    }
 
-        if ($resolved === null) {
-            return Result::failure($output, "More than 1 bin command found in {$this->root}: ".implode(', ', array_keys($this->localBinaries)).'.');
-        }
+    public function shouldCheckForUpdates(): bool
+    {
+        throw self::noCacheLifecycle(__FUNCTION__);
+    }
 
-        $binPath = Filesystem::joinPath($this->root, $resolved->command);
-
-        if (! is_file($binPath)) {
-            return Result::failure($output, 'Command '.basename($resolved->command)." not found in {$this->root}.");
-        }
-
-        info('Running '.basename($resolved->command)." from {$this->root}");
-
-        return (new ProcessRunner)->run(BinExecutable::commandFor($binPath, $resolved->invocation->forwardedTokens()));
+    protected function recordRun(): void
+    {
+        // Local packages are not tracked in the cache metadata.
     }
 
     private static function expandHomeDirectory(string $path): string
@@ -193,23 +188,8 @@ class LocalPackage extends Package
         return basename(Filesystem::normalizePath($name));
     }
 
-    /**
-     * @param  array<array-key, mixed>  $composer
-     * @return array<string, string>
-     */
-    private static function manifestBinaries(array $composer): array
+    private static function noCacheLifecycle(string $method): BadMethodCallException
     {
-        $declared = $composer['bin'] ?? [];
-        $binaries = [];
-
-        foreach ((array) $declared as $binary) {
-            if (! is_string($binary) || $binary === '') {
-                continue;
-            }
-
-            $binaries[basename(Filesystem::normalizePath($binary))] = $binary;
-        }
-
-        return $binaries;
+        return new BadMethodCallException("{$method}() is not supported for local packages; they are not managed in the cpx package cache.");
     }
 }

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -9,7 +9,6 @@ use Cpx\Composer\ComposerRunner;
 use Cpx\Exceptions\PackageNotFoundException;
 use Cpx\Input\PackageInvocation;
 use Cpx\Process\ProcessRunner;
-use Cpx\Support\Arr;
 use Cpx\Support\Filesystem;
 use Cpx\Support\Interactivity;
 use Cpx\Support\Result;
@@ -21,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function Laravel\Prompts\info;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\task;
 
@@ -49,7 +49,7 @@ class Package
 
     public static function parse(string $str): self
     {
-        if (empty($str)) {
+        if ($str === '') {
             throw new InvalidArgumentException('A package name must be provided.');
         }
 
@@ -121,9 +121,7 @@ class Package
      */
     public function binaries(string $installDir): array
     {
-        $binScripts = ComposerRunner::detectBinFromComposer($this->packagePath($installDir));
-
-        return Arr::mapWithKeys(fn (int $_, string $value): array => [basename($value) => $value], $binScripts);
+        return self::mapBinaries(ComposerRunner::detectBinFromComposer($this->packagePath($installDir)));
     }
 
     public function delete(): void
@@ -144,10 +142,9 @@ class Package
 
             return Result::failure($output, $exception->getMessage());
         }
-        $packageDir = $this->packagePath($installDir);
         $binScripts = $this->binaries($installDir);
 
-        if (empty($binScripts)) {
+        if ($binScripts === []) {
             return Result::failure($output, "No bin command found in {$this}.");
         }
 
@@ -158,19 +155,15 @@ class Package
             return Result::failure($output, "More than 1 bin command found for {$this}: ".implode(', ', array_keys($binScripts)).'.');
         }
 
-        $binPath = "{$packageDir}/{$resolved->command}";
+        $binPath = "{$this->packagePath($installDir)}/{$resolved->command}";
 
-        if (! file_exists($binPath)) {
+        if (! is_file($binPath)) {
             return Result::failure($output, 'Command '.basename($resolved->command)." not found in {$this}.");
         }
 
-        task(
-            label: 'Running '.basename($resolved->command)." from {$this}",
-            callback: fn (Logger $_logger): mixed => Metadata::transaction(
-                fn (Metadata $metadata) => $metadata->recordRun($this),
-            ),
-            keepSummary: true,
-        );
+        $this->recordRun();
+
+        info('Running '.basename($resolved->command)." from {$this}");
 
         return (new ProcessRunner)->run(BinExecutable::commandFor($binPath, $resolved->invocation->forwardedTokens()));
     }
@@ -209,6 +202,29 @@ class Package
         }
 
         return (time() - $lastUpdatedAt) > Metadata::UPDATE_CHECK_INTERVAL;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function mapBinaries(mixed $declared): array
+    {
+        $binaries = [];
+
+        foreach ((array) $declared as $binary) {
+            if (! is_string($binary) || $binary === '') {
+                continue;
+            }
+
+            $binaries[basename(Filesystem::normalizePath($binary))] = $binary;
+        }
+
+        return $binaries;
+    }
+
+    protected function recordRun(): void
+    {
+        Metadata::transaction(fn (Metadata $metadata) => $metadata->recordRun($this));
     }
 
     /**

--- a/src/Packages/Package.php
+++ b/src/Packages/Package.php
@@ -269,49 +269,24 @@ class Package
         task(
             label: "Installing {$this}",
             callback: function (Logger $logger) use ($installDir): void {
-                $cacheRoot = cpx_path();
-                Filesystem::ensureDirectory($cacheRoot);
-
-                $stagingDir = "{$installDir}.installing.".getmypid();
-                ProcessRunner::withLogger($logger, fn () => $this->stageInstall($stagingDir, $cacheRoot));
-
-                Filesystem::deleteDirectory($installDir);
-
-                try {
-                    Filesystem::replaceDirectory($stagingDir, $installDir);
-                } catch (RuntimeException $exception) {
-                    Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-
-                    throw new RuntimeException("Unable to finalize the installation of {$this}; another process may be holding files under {$installDir}.", previous: $exception);
-                }
+                StagedInstall::run(
+                    targetDir: $installDir,
+                    scaffold: [
+                        'name' => "cpx-{$this->vendor}/cpx-{$this->name}",
+                        'version' => self::SCAFFOLD_VERSION,
+                        'config' => [
+                            // Requested packages may ship Composer plugins (binaries, installers).
+                            'allow-plugins' => true,
+                        ],
+                    ],
+                    install: fn (string $stagingDir) => ProcessRunner::withLogger($logger, fn () => ComposerRunner::require($this->fullPackageString(), $stagingDir)),
+                    finalizeFailure: fn (RuntimeException $exception): Throwable => new RuntimeException("Unable to finalize the installation of {$this}; another process may be holding files under {$installDir}.", previous: $exception),
+                );
 
                 Metadata::transaction(fn (Metadata $metadata) => $metadata->recordUpdate($this));
             },
             keepSummary: true,
         );
-    }
-
-    private function stageInstall(string $stagingDir, string $cacheRoot): void
-    {
-        Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-        Filesystem::ensureDirectory($stagingDir);
-
-        file_put_contents("{$stagingDir}/composer.json", json_encode([
-            'name' => "cpx-{$this->vendor}/cpx-{$this->name}",
-            'version' => self::SCAFFOLD_VERSION,
-            'config' => [
-                // Requested packages may ship Composer plugins (binaries, installers).
-                'allow-plugins' => true,
-            ],
-        ]));
-
-        try {
-            ComposerRunner::require($this->fullPackageString(), $stagingDir);
-        } catch (Throwable $exception) {
-            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
-
-            throw $exception;
-        }
     }
 
     private function updatePackage(string $installDir): void

--- a/src/Packages/PackageCommandRunner.php
+++ b/src/Packages/PackageCommandRunner.php
@@ -28,8 +28,8 @@ class PackageCommandRunner
 
         try {
             $package = $this->findPackage($invocation->target);
-        } catch (InvalidArgumentException) {
-            return $this->unrecognised($invocation->target, $output);
+        } catch (InvalidArgumentException $exception) {
+            return Result::failure($output, $exception->getMessage());
         }
 
         if ($package instanceof LocalPackage) {

--- a/src/Packages/PackageCommandRunner.php
+++ b/src/Packages/PackageCommandRunner.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\info;
-use function Laravel\Prompts\task;
 
 /**
  * Runs a non-built-in cpx target by resolving it to a local PHP file, an
@@ -67,11 +66,7 @@ class PackageCommandRunner
 
     private function runLocal(ResolvedBin $resolved): int
     {
-        task(
-            label: 'Running '.basename($resolved->command)." from {$resolved->command}",
-            callback: fn (): bool => true,
-            keepSummary: true,
-        );
+        info('Running '.basename($resolved->command)." from {$resolved->command}");
 
         return (new ProcessRunner)->run(BinExecutable::commandFor($resolved->command, $resolved->invocation->forwardedTokens()));
     }

--- a/src/Packages/StagedInstall.php
+++ b/src/Packages/StagedInstall.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Packages;
+
+use Closure;
+use Cpx\Support\Filesystem;
+use RuntimeException;
+use Throwable;
+
+/** Installs into a sibling ".installing.<pid>" staging directory and atomically swaps it into the target. */
+class StagedInstall
+{
+    /**
+     * @param  array<string, mixed>  $scaffold
+     * @param  Closure(string): void  $install
+     * @param  Closure(RuntimeException): Throwable  $finalizeFailure
+     */
+    public static function run(string $targetDir, array $scaffold, Closure $install, Closure $finalizeFailure): void
+    {
+        $cacheRoot = cpx_path();
+        Filesystem::ensureDirectory($cacheRoot);
+
+        $stagingDir = "{$targetDir}.installing.".getmypid();
+        Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+        Filesystem::ensureDirectory($stagingDir);
+
+        file_put_contents("{$stagingDir}/composer.json", json_encode($scaffold, JSON_PRETTY_PRINT));
+
+        try {
+            $install($stagingDir);
+        } catch (Throwable $exception) {
+            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+
+            throw $exception;
+        }
+
+        try {
+            Filesystem::replaceDirectory($stagingDir, $targetDir);
+        } catch (RuntimeException $exception) {
+            Filesystem::deleteDirectoryWithin($stagingDir, $cacheRoot);
+
+            throw $finalizeFailure($exception);
+        }
+    }
+}

--- a/tests/Feature/BinaryResolutionTest.php
+++ b/tests/Feature/BinaryResolutionTest.php
@@ -67,6 +67,21 @@ test('ambiguous multiple-binary packages prompt for the binary to run', function
         ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['--flag']);
 })->skipOnWindows();
 
+test('a positional token spelling a package-named binary is forwarded, not consumed', function () {
+    $this->useIsolatedComposerHome();
+    $logFile = $this->temporaryDirectory('cpx-log').'/argv.json';
+
+    prepareCachedPackage('vendor/pkg', ['pkg', 'other'], [
+        'pkg' => "#!/usr/bin/env php\n<?php file_put_contents('{$logFile}', json_encode(array_slice(\$argv, 1), JSON_THROW_ON_ERROR)); exit(0);\n",
+        'other' => "#!/usr/bin/env php\n<?php exit(99);\n",
+    ]);
+
+    [$status] = runCpxCommand(['vendor/pkg', 'pkg', 'tests/Sub']);
+
+    expect($status)->toBe(0)
+        ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['pkg', 'tests/Sub']);
+});
+
 test('ambiguous multiple-binary packages list the available binaries when the terminal cannot prompt', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/BinaryResolutionTest.php
+++ b/tests/Feature/BinaryResolutionTest.php
@@ -82,6 +82,35 @@ test('a positional token spelling a package-named binary is forwarded, not consu
         ->and(json_decode((string) file_get_contents($logFile), true))->toBe(['pkg', 'tests/Sub']);
 });
 
+test('ambiguity errors share wording for cached and local packages', function () {
+    $this->useIsolatedComposerHome();
+
+    prepareCachedPackage('vendor/package', ['foo', 'bar'], [
+        'foo' => "#!/usr/bin/env php\n<?php exit(0);\n",
+        'bar' => "#!/usr/bin/env php\n<?php exit(0);\n",
+    ]);
+    $root = $this->prepareLocalPackage(['bin/foo', 'bin/bar'], 'vendor/local');
+
+    [, $cachedOutput] = runCpxCommand(['vendor/package']);
+    [, $localOutput] = runCpxCommand([$root]);
+
+    expect($cachedOutput)->toContain('More than 1 bin command found for vendor/package: foo, bar.')
+        ->and($localOutput)->toContain("More than 1 bin command found for {$root}: foo, bar.");
+});
+
+test('missing binary errors share wording for cached and local packages', function () {
+    $this->useIsolatedComposerHome();
+
+    prepareCachedPackage('vendor/ghost', ['ghost']);
+    $root = $this->prepareLocalPackage(['bin/missing'], 'vendor/local');
+
+    [, $cachedOutput] = runCpxCommand(['vendor/ghost']);
+    [, $localOutput] = runCpxCommand([$root]);
+
+    expect($cachedOutput)->toContain('Command ghost not found in vendor/ghost.')
+        ->and($localOutput)->toContain("Command missing not found in {$root}.");
+});
+
 test('ambiguous multiple-binary packages list the available binaries when the terminal cannot prompt', function () {
     $this->useIsolatedComposerHome();
 

--- a/tests/Feature/CommandBehaviorTest.php
+++ b/tests/Feature/CommandBehaviorTest.php
@@ -306,8 +306,18 @@ test('package-looking values with shell metacharacters fail before composer exec
     [$status, $output] = runCpxCommand(['vendor/package;touch injected']);
 
     expect($status)->toBe(1)
-        ->and($output)->toContain('Unrecognised command vendor/package;touch injected')
+        ->and($output)->toContain('A package name should be in the format')
         ->and($calls)->toBe([]);
+});
+
+test('an unparseable slash target surfaces the package format hint', function () {
+    $this->useIsolatedComposerHome();
+
+    [$status, $output] = runCpxCommand(['bad//ref']);
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('A package name should be in the format "<vendor>/<package>[:version]".')
+        ->and($output)->not->toContain('Unrecognised command');
 });
 
 test('invalid fallback commands return a failure status with help output', function () {

--- a/tests/Feature/LocalPackageDirectoryTest.php
+++ b/tests/Feature/LocalPackageDirectoryTest.php
@@ -202,7 +202,7 @@ test('an ambiguous local multi-bin package lists its binaries when the terminal 
     [$status, $output] = runCpxCommand([$root]);
 
     expect($status)->toBe(1)
-        ->and($output)->toContain("More than 1 bin command found in {$root}: foo, bar.");
+        ->and($output)->toContain("More than 1 bin command found for {$root}: foo, bar.");
 });
 
 test('a local package must declare a binary', function () {

--- a/tests/Unit/BinResolverTest.php
+++ b/tests/Unit/BinResolverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Cpx\Input\PackageInvocation;
+use Cpx\Packages\BinResolver;
+
+test('a bin matching the package name wins without consuming a forwarded token', function () {
+    $invocation = new PackageInvocation('vendor/pkg', ['pkg', 'tests/path']);
+
+    $resolved = BinResolver::resolve(['pkg' => 'pkg', 'other' => 'other'], $invocation, 'pkg');
+
+    expect($resolved?->command)->toBe('pkg')
+        ->and($resolved?->invocation->forwardedTokens())->toBe(['pkg', 'tests/path']);
+});
+
+test('a bin matching the target does not consume a forwarded token of the same name', function () {
+    $invocation = new PackageInvocation('tool', ['tool', '--flag']);
+
+    $resolved = BinResolver::resolve(['tool' => 'tool', 'other' => 'other'], $invocation, 'package');
+
+    expect($resolved?->command)->toBe('tool')
+        ->and($resolved?->invocation->forwardedTokens())->toBe(['tool', '--flag']);
+});
+
+test('a forwarded token selects a bin and is consumed', function () {
+    $invocation = new PackageInvocation('vendor/pkg', ['bar', '--flag']);
+
+    $resolved = BinResolver::resolve(['foo' => 'foo', 'bar' => 'bar'], $invocation, 'pkg');
+
+    expect($resolved?->command)->toBe('bar')
+        ->and($resolved?->invocation->forwardedTokens())->toBe(['--flag']);
+});
+
+test('an unmatched multi-bin package resolves to null', function () {
+    $invocation = new PackageInvocation('vendor/pkg', ['--flag']);
+
+    $resolved = BinResolver::resolve(['foo' => 'foo', 'bar' => 'bar'], $invocation, 'pkg');
+
+    expect($resolved)->toBeNull();
+});
+
+test('a single bin resolves regardless of candidates', function () {
+    $invocation = new PackageInvocation('vendor/pkg', ['anything']);
+
+    $resolved = BinResolver::resolve(['tool' => 'bin/tool'], $invocation, 'pkg');
+
+    expect($resolved?->command)->toBe('bin/tool')
+        ->and($resolved?->invocation->forwardedTokens())->toBe(['anything']);
+});
+
+test('a pinned bin resolves without consuming forwarded tokens', function () {
+    $invocation = new PackageInvocation('tool', ['foo', '--flag']);
+
+    $resolved = BinResolver::resolve(['foo' => 'foo', 'bar' => 'bar'], $invocation, 'pkg', 'bar');
+
+    expect($resolved?->command)->toBe('bar')
+        ->and($resolved?->invocation->forwardedTokens())->toBe(['foo', '--flag']);
+});

--- a/tests/Unit/ExecSandboxTest.php
+++ b/tests/Unit/ExecSandboxTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Cpx\Cache\Metadata;
+use Cpx\Composer\ComposerRunner;
+use Cpx\Exceptions\ComposerInstallException;
+use Cpx\Packages\ExecSandbox;
+use Laravel\Prompts\Output\BufferedConsoleOutput;
+use Laravel\Prompts\Prompt;
+
+test('a staged sandbox install lands the final directory and removes the staging directory', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls);
+
+    $path = ExecSandbox::forPackages(['laravel/pint'])->ensureInstalled();
+
+    expect(file_exists("{$path}/vendor/autoload.php"))->toBeTrue()
+        ->and(glob(cpx_path('.exec_cache/*.installing.*')) ?: [])->toBe([]);
+});
+
+test('a failing staged sandbox install cleans up staging and raises the component exception', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls, exitCode: 1);
+
+    $sandbox = ExecSandbox::forPackages(['laravel/pint']);
+
+    expect(fn () => $sandbox->ensureInstalled())
+        ->toThrow(ComposerInstallException::class, 'Failed to install package: laravel/pint.');
+
+    expect(is_dir($sandbox->path()))->toBeFalse()
+        ->and(glob(cpx_path('.exec_cache/*.installing.*')) ?: [])->toBe([]);
+});
+
+test('a failed sandbox update warns and keeps the existing install working', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls);
+
+    $sandbox = ExecSandbox::forPackages(['laravel/pint']);
+    $sandbox->ensureInstalled();
+
+    Metadata::transaction(function (Metadata $metadata) use ($sandbox): void {
+        $metadata->execCache[$sandbox->key]->lastUpdatedAt = time() - 2 * Metadata::UPDATE_CHECK_INTERVAL;
+    });
+
+    fakeComposer($calls, exitCode: 1);
+    Prompt::setOutput($buffer = new BufferedConsoleOutput);
+
+    $path = $sandbox->ensureInstalled();
+
+    expect($path)->toBe($sandbox->path())
+        ->and($buffer->fetch())->toContain('Could not update the exec sandbox');
+});
+
+test('an unexpected non-composer failure during a sandbox update propagates', function () {
+    $this->useIsolatedComposerHome();
+
+    $calls = [];
+    fakeComposer($calls);
+
+    $sandbox = ExecSandbox::forPackages(['laravel/pint']);
+    $sandbox->ensureInstalled();
+
+    Metadata::transaction(function (Metadata $metadata) use ($sandbox): void {
+        $metadata->execCache[$sandbox->key]->lastUpdatedAt = time() - 2 * Metadata::UPDATE_CHECK_INTERVAL;
+    });
+
+    ComposerRunner::fake(function (): int {
+        throw new LogicException('boom');
+    });
+
+    expect(fn () => $sandbox->ensureInstalled())->toThrow(LogicException::class, 'boom');
+});

--- a/tests/Unit/LocalPackageTest.php
+++ b/tests/Unit/LocalPackageTest.php
@@ -32,6 +32,21 @@ test('it exposes the canonical root and composer package short name', function (
         ->and($package->name)->toBe('tool');
 });
 
+test('it filters non-string manifest bin entries', function () {
+    $root = $this->prepareLocalPackage(['bin/tool', 123, null]);
+
+    expect(LocalPackage::parse($root)->binaries(''))->toBe(['tool' => 'bin/tool']);
+});
+
+test('cache lifecycle members throw for local packages', function () {
+    $package = LocalPackage::parse($this->prepareLocalPackage());
+
+    expect(fn () => $package->installPath())->toThrow(BadMethodCallException::class)
+        ->and(fn () => $package->delete())->toThrow(BadMethodCallException::class)
+        ->and(fn () => $package->isInstalled())->toThrow(BadMethodCallException::class)
+        ->and(fn () => $package->shouldCheckForUpdates())->toThrow(BadMethodCallException::class);
+});
+
 test('it rejects a non-directory path when resolved directly', function () {
     $root = $this->temporaryDirectory('cpx-local-package');
     $path = "{$root}/package.txt";

--- a/tests/Unit/PackageTest.php
+++ b/tests/Unit/PackageTest.php
@@ -34,6 +34,14 @@ test('it accepts composer package names with supported punctuation', function (s
     'vendor123/package.456',
 ]);
 
+test('binaries filters non-string manifest bin entries', function () {
+    $installDir = $this->temporaryDirectory('cpx-install');
+    mkdir("{$installDir}/vendor/vendor/pkg", 0755, true);
+    file_put_contents("{$installDir}/vendor/vendor/pkg/composer.json", json_encode(['bin' => ['bin/tool', 123, null]], JSON_THROW_ON_ERROR));
+
+    expect(Package::parse('vendor/pkg')->binaries($installDir))->toBe(['tool' => 'bin/tool']);
+});
+
 test('it rejects invalid package targets', function (string $target) {
     Package::parse($target);
 })->with([


### PR DESCRIPTION
## Overview

Cached and local packages each carry their own copy of the run flow, and package installs and exec sandboxes each stage installs their own way. The duplicated paths had already drifted apart: the two run flows worded their errors differently, and a positional argument spelling a package-named binary was silently consumed instead of forwarded.

## Solution

One run flow now lives in `Package` — binary resolution, interactive prompting, error reporting, and run recording — with `LocalPackage` overriding only the cache-specific pieces, and the staging dance is extracted into a `StagedInstall` helper shared by package installs and exec sandboxes. Along the way, `BinResolver` keeps positional arguments when a bin matches the package name, and unparseable targets surface the expected `<vendor>/<package>[:version]` format hint.

## Details

The branch is reconciled with the latest 2.x changes: the shared run flow keeps the interactive binary prompt from #45 (local packages now get it too), and staged installs go through `ComposerRunner::require` from #46 so only genuinely missing packages are reported as not found.