### PR TITLE
Fix class aliasing and unknown classes in the child runtime

### DIFF
--- a/files/child-runtime.php
+++ b/files/child-runtime.php
@@ -8,8 +8,14 @@ use Cpx\Runtime\CpxRequire;
  * keeping the phar's bundled dependencies out of the child.
  */
 spl_autoload_register(static function (string $class): void {
-    if (str_starts_with($class, 'Cpx\\Runtime\\')) {
-        require __DIR__.'/../src/Runtime/'.substr($class, strlen('Cpx\\Runtime\\')).'.php';
+    if (! str_starts_with($class, 'Cpx\\Runtime\\')) {
+        return;
+    }
+
+    $path = __DIR__.'/../src/Runtime/'.str_replace('\\', '/', substr($class, strlen('Cpx\\Runtime\\'))).'.php';
+
+    if (is_file($path)) {
+        require $path;
     }
 });
 

--- a/src/Runtime/ClassAliasAutoloader.php
+++ b/src/Runtime/ClassAliasAutoloader.php
@@ -31,9 +31,8 @@ class ClassAliasAutoloader
 
                 $name = basename(str_replace('\\', '/', $class));
 
-                if (! isset($this->classes[$name]) && class_exists($name)) {
-                    $this->classes[$name] = $class;
-                }
+                // Register lazily; aliasClass() validates loadability when the alias is requested.
+                $this->classes[$name] ??= $class;
             }
         }
 

--- a/src/Runtime/PhpExecutionHelper.php
+++ b/src/Runtime/PhpExecutionHelper.php
@@ -30,8 +30,9 @@ class PhpExecutionHelper
                 echo 'Aliasing classes'.PHP_EOL;
             }
 
-            static::getClassAliasAutoloader($context->verbose)->addAliases($context->autoloadRoot);
-            spl_autoload_register(static::getClassAliasAutoloader($context->verbose)->aliasClass(...));
+            $autoloader = static::$classAliasAutoloader ??= new ClassAliasAutoloader($context->verbose);
+            $autoloader->addAliases($context->autoloadRoot);
+            spl_autoload_register($autoloader->aliasClass(...));
         }
 
         return $variables;
@@ -53,10 +54,5 @@ class PhpExecutionHelper
         }
 
         return $root;
-    }
-
-    public static function getClassAliasAutoloader(bool $shouldBeVerbose = false): ClassAliasAutoloader
-    {
-        return static::$classAliasAutoloader ??= new ClassAliasAutoloader($shouldBeVerbose);
     }
 }

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -39,9 +39,11 @@ arch('the package source declares strict types')
 test('the app does not call proc_open directly', function () {
     // CpxRequire runs inside the dependency-free child, where ProcessRunner is unavailable by design.
     // ExecCommandTest closes a raw stdout pipe mid-stream to prove ProcessRunner reports failed writes.
+    // ChildScriptTest captures a raw child's stdout to prove the child-runtime autoloader declines unknown classes.
     $offenders = sourceFilesContaining('proc_open', except: [
         'src/Runtime/CpxRequire.php',
         'tests/Feature/ExecCommandTest.php',
+        'tests/Unit/ChildScriptTest.php',
     ]);
 
     expect($offenders)->toBe([]);

--- a/tests/Unit/ChildScriptTest.php
+++ b/tests/Unit/ChildScriptTest.php
@@ -3,6 +3,30 @@
 use Cpx\Runtime\Environment;
 use Cpx\Support\ChildScript;
 
+test('the child runtime autoloader declines unknown classes', function () {
+    $process = proc_open(
+        [
+            PHP_BINARY,
+            '-r',
+            'require $argv[1]; var_dump(class_exists("Cpx\\\\Runtime\\\\Missing"));',
+            '--',
+            dirname(__DIR__, 2).'/files/child-runtime.php',
+        ],
+        [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+        $pipes,
+    );
+
+    assert(is_resource($process));
+
+    $output = (string) stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $status = proc_close($process);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('bool(false)');
+});
+
 test('it returns the bundled script path when not running from a phar', function () {
     $expected = dirname(__DIR__, 2).'/files/exec-bootstrap.php';
 

--- a/tests/Unit/ClassAliasAutoloaderTest.php
+++ b/tests/Unit/ClassAliasAutoloaderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Cpx\Runtime\ClassAliasAutoloader;
+
+/**
+ * @param  array<string, string>  $classmap
+ * @param  array<string, list<string>>  $psr4
+ */
+function aliasAutoloadRoot(string $root, array $classmap = [], array $psr4 = []): void
+{
+    mkdir("{$root}/vendor/composer", 0755, true);
+    file_put_contents("{$root}/vendor/composer/autoload_classmap.php", '<?php return '.var_export($classmap, true).';');
+    file_put_contents("{$root}/vendor/composer/autoload_psr4.php", '<?php return '.var_export($psr4, true).';');
+}
+
+test('loadable classmap entries register short-name aliases', function () {
+    $root = $this->temporaryDirectory('cpx-alias');
+    aliasAutoloadRoot($root, classmap: ['Cpx\Runtime\CpxRequire' => 'src/Runtime/CpxRequire.php']);
+
+    $autoloader = new ClassAliasAutoloader;
+    $autoloader->addAliases($root);
+    $autoloader->aliasClass('CpxRequire');
+
+    expect(class_exists('CpxRequire', false))->toBeTrue()
+        ->and((new ReflectionClass('CpxRequire'))->getName())->toBe('Cpx\Runtime\CpxRequire');
+});
+
+test('classmap entries that cannot be loaded are never aliased', function () {
+    $root = $this->temporaryDirectory('cpx-alias');
+    aliasAutoloadRoot($root, classmap: ['Cpx\Missing\GhostClass' => 'src/Missing/GhostClass.php']);
+
+    $autoloader = new ClassAliasAutoloader;
+    $autoloader->addAliases($root);
+    $autoloader->aliasClass('GhostClass');
+
+    expect(class_exists('GhostClass', false))->toBeFalse();
+});
+
+test('already-taken short names keep their first classmap registration', function () {
+    $root = $this->temporaryDirectory('cpx-alias');
+    aliasAutoloadRoot($root, classmap: [
+        'Cpx\Support\Filesystem' => 'src/Support/Filesystem.php',
+        'Composer\Util\Filesystem' => 'src/Util/Filesystem.php',
+    ]);
+
+    $autoloader = new ClassAliasAutoloader;
+    $autoloader->addAliases($root);
+    $autoloader->aliasClass('Filesystem');
+
+    expect((new ReflectionClass('Filesystem'))->getName())->toBe('Cpx\Support\Filesystem');
+});
+
+test('psr4 roots register aliases for their php files', function () {
+    $root = $this->temporaryDirectory('cpx-alias');
+    $sources = $this->temporaryDirectory('cpx-alias-src');
+    file_put_contents("{$sources}/ExecVariable.php", '<?php');
+    aliasAutoloadRoot($root, psr4: ['Cpx\Runtime\\' => [$sources]]);
+
+    $autoloader = new ClassAliasAutoloader;
+    $autoloader->addAliases($root);
+    $autoloader->aliasClass('ExecVariable');
+
+    expect(class_exists('ExecVariable', false))->toBeTrue()
+        ->and((new ReflectionClass('ExecVariable'))->getName())->toBe('Cpx\Runtime\ExecVariable');
+});
+
+test('aliasClass ignores unknown and namespace-qualified names', function () {
+    $autoloader = new ClassAliasAutoloader;
+
+    $autoloader->aliasClass('TotallyUnknownClass');
+    $autoloader->aliasClass('Cpx\Runtime\Context');
+
+    expect(class_exists('TotallyUnknownClass', false))->toBeFalse();
+});


### PR DESCRIPTION
## Overview

The child runtime that powers `exec` and `tinker` has two autoloading defects. Classmap aliases were only registered when a class with the same short name could already be loaded — an inverted check, since aliases exist precisely for short names that are not loadable yet — so the aliases that mattered were never created. And the child's `spl_autoload` callback blindly required a file path derived from any `Cpx\Runtime\*` class name, causing a fatal error for class names that do not map to a real file.

## Solution

Alias candidates are now registered unconditionally and validated lazily when the alias is actually requested, and the child autoloader maps namespace separators to directories and only requires files that exist. Both autoloaders get dedicated unit coverage.