### PR TITLE
Harden and deduplicate the Filesystem helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/Support/FilesystemFakes.php"
+        ]
     },
     "require": {
         "php": "^8.3"

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -193,8 +193,6 @@ class CleanCommand extends Command
             $tracked[Filesystem::normalizePath($packageMetadata->installPath())] = $key;
         }
 
-        $cacheRoot = Filesystem::normalizePath(cpx_path());
-
         foreach (glob(cpx_path('*/*/*'), GLOB_ONLYDIR) ?: [] as $directory) {
             $normalizedDirectory = Filesystem::normalizePath($directory);
             $trackedKey = $tracked[$normalizedDirectory] ?? null;
@@ -203,7 +201,7 @@ class CleanCommand extends Command
                 continue;
             }
 
-            $description = 'orphaned package '.str_replace($cacheRoot, '', $normalizedDirectory);
+            $description = 'orphaned package '.Filesystem::relativePath($directory, cpx_path());
 
             if (! $this->remove($directory, $description, $result, $logger)) {
                 continue;

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -140,7 +140,7 @@ class UpdateCommand extends Command
 
     protected function updateDirectory(string $directory): void
     {
-        $relative = ltrim(str_replace(Filesystem::normalizePath(cpx_path()), '', Filesystem::normalizePath($directory)), '/');
+        $relative = Filesystem::relativePath($directory, cpx_path());
         $package = implode('/', array_slice(explode('/', $relative), 0, 2));
 
         if ($this->json) {

--- a/src/Packages/LocalPackage.php
+++ b/src/Packages/LocalPackage.php
@@ -152,31 +152,12 @@ class LocalPackage extends Package
             return $path;
         }
 
-        $home = self::homeDirectory();
+        $home = Filesystem::homeDirectory()
+            ?? throw new InvalidArgumentException('Unable to expand the local package path because the home directory could not be determined.');
 
         return $path === '~'
             ? $home
             : Filesystem::joinPath($home, substr($path, 2));
-    }
-
-    private static function homeDirectory(): string
-    {
-        foreach (['HOME', 'USERPROFILE'] as $variable) {
-            $home = $_SERVER[$variable] ?? getenv($variable);
-
-            if (is_string($home) && $home !== '') {
-                return rtrim($home, '/\\');
-            }
-        }
-
-        $drive = $_SERVER['HOMEDRIVE'] ?? getenv('HOMEDRIVE');
-        $homePath = $_SERVER['HOMEPATH'] ?? getenv('HOMEPATH');
-
-        if (is_string($drive) && $drive !== '' && is_string($homePath) && $homePath !== '') {
-            return rtrim("{$drive}{$homePath}", '/\\');
-        }
-
-        throw new InvalidArgumentException('Unable to expand the local package path because the home directory could not be determined.');
     }
 
     /**

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -37,6 +37,26 @@ class Filesystem
             || preg_match('/\A[a-zA-Z]:[\\\\\/]/', $path) === 1;
     }
 
+    public static function homeDirectory(): ?string
+    {
+        foreach (['HOME', 'USERPROFILE'] as $variable) {
+            $home = $_SERVER[$variable] ?? getenv($variable);
+
+            if (is_string($home) && $home !== '') {
+                return rtrim($home, '/\\');
+            }
+        }
+
+        $drive = $_SERVER['HOMEDRIVE'] ?? getenv('HOMEDRIVE');
+        $homePath = $_SERVER['HOMEPATH'] ?? getenv('HOMEPATH');
+
+        if (is_string($drive) && $drive !== '' && is_string($homePath) && $homePath !== '') {
+            return rtrim("{$drive}{$homePath}", '/\\');
+        }
+
+        return null;
+    }
+
     public static function ensureDirectory(string $directory): void
     {
         if (is_dir($directory)) {

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -37,6 +37,11 @@ class Filesystem
             || preg_match('/\A[a-zA-Z]:[\\\\\/]/', $path) === 1;
     }
 
+    public static function relativePath(string $path, string $base): string
+    {
+        return ltrim(str_replace(self::normalizePath($base), '', self::normalizePath($path)), '/');
+    }
+
     public static function homeDirectory(): ?string
     {
         foreach (['HOME', 'USERPROFILE'] as $variable) {

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -80,11 +80,20 @@ class Filesystem
             throw new RuntimeException("Unable to write to {$temporaryPath}.");
         }
 
-        if (! rename($temporaryPath, $path)) {
-            self::deleteFile($temporaryPath);
+        // Retry transient (Windows file-lock) failures, mirroring replaceDirectory().
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            if ($attempt > 1) {
+                usleep(100_000);
+            }
 
-            throw new RuntimeException("Unable to move {$temporaryPath} to {$path}.");
+            if (@rename($temporaryPath, $path)) {
+                return;
+            }
         }
+
+        self::deleteFile($temporaryPath);
+
+        throw new RuntimeException("Unable to move {$temporaryPath} to {$path}.");
     }
 
     public static function deleteDirectoryWithin(string $path, string $root): void

--- a/src/functions.php
+++ b/src/functions.php
@@ -29,21 +29,12 @@ if (! function_exists('cpx_path')) {
             return Filesystem::joinPath($cpxHome, $path);
         }
 
-        foreach (['HOME', 'USERPROFILE'] as $variable) {
-            $home = $_SERVER[$variable] ?? getenv($variable);
+        $home = Filesystem::homeDirectory();
 
-            if (is_string($home) && $home !== '') {
-                return Filesystem::joinPath($home, '.cpx', $path);
-            }
+        if ($home === null) {
+            throw new RuntimeException('Unable to determine the home directory; set the CPX_HOME, HOME, or USERPROFILE environment variable.');
         }
 
-        $drive = $_SERVER['HOMEDRIVE'] ?? getenv('HOMEDRIVE');
-        $homePath = $_SERVER['HOMEPATH'] ?? getenv('HOMEPATH');
-
-        if (is_string($drive) && $drive !== '' && is_string($homePath) && $homePath !== '') {
-            return Filesystem::joinPath("{$drive}{$homePath}", '.cpx', $path);
-        }
-
-        throw new RuntimeException('Unable to determine the home directory; set the CPX_HOME, HOME, or USERPROFILE environment variable.');
+        return Filesystem::joinPath($home, '.cpx', $path);
     }
 }

--- a/tests/Feature/CleanCommandTest.php
+++ b/tests/Feature/CleanCommandTest.php
@@ -286,7 +286,7 @@ test('orphaned package directories are detected and cleaned', function () {
 
     expect($status)->toBe(0)
         ->and(is_dir($orphan))->toBeFalse()
-        ->and($output)->toContain('orphan/package/latest');
+        ->and($output)->toContain('orphaned package orphan/package/latest');
 });
 
 test('incomplete install directories are treated as orphaned and removed', function () {

--- a/tests/Support/FilesystemFakes.php
+++ b/tests/Support/FilesystemFakes.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Support;
+
+/**
+ * Overrides the global rename() inside the Cpx\Support namespace so tests can
+ * induce the transient failures that Filesystem retries.
+ */
+function rename(string $from, string $to): bool
+{
+    if (FilesystemFake::$failingRenames > 0) {
+        FilesystemFake::$failingRenames--;
+
+        return false;
+    }
+
+    return \rename($from, $to);
+}
+
+class FilesystemFake
+{
+    public static int $failingRenames = 0;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Cpx\Gists\GistClient;
 use Cpx\Packages\BinExecutable;
 use Cpx\Process\ProcessRunner;
 use Cpx\Runtime\Environment;
+use Cpx\Support\FilesystemFake;
 use Cpx\Support\Interactivity;
 use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Laravel\Prompts\Prompt;
@@ -56,6 +57,7 @@ abstract class TestCase extends BaseTestCase
         ProcessRunner::clearFake();
         ProcessRunner::clearFakeInput();
         Interactivity::clearFake();
+        FilesystemFake::$failingRenames = 0;
 
         if ($this->workingDirectory !== null) {
             chdir($this->workingDirectory);

--- a/tests/Unit/FilesystemTest.php
+++ b/tests/Unit/FilesystemTest.php
@@ -2,6 +2,32 @@
 
 use Composer\Util\Filesystem as ComposerFilesystem;
 use Cpx\Support\Filesystem;
+use Cpx\Support\FilesystemFake;
+
+test('writeAtomic retries a transient rename failure', function () {
+    $directory = $this->temporaryDirectory('cpx-fs');
+    $path = "{$directory}/data.json";
+
+    FilesystemFake::$failingRenames = 1;
+
+    Filesystem::writeAtomic($path, 'contents');
+
+    expect(file_get_contents($path))->toBe('contents')
+        ->and(glob("{$directory}/*.tmp"))->toBe([]);
+});
+
+test('writeAtomic gives up after three failed renames and cleans its temp file', function () {
+    $directory = $this->temporaryDirectory('cpx-fs');
+    $path = "{$directory}/data.json";
+
+    FilesystemFake::$failingRenames = 3;
+
+    expect(fn () => Filesystem::writeAtomic($path, 'contents'))
+        ->toThrow(RuntimeException::class, 'Unable to move');
+
+    expect(file_exists($path))->toBeFalse()
+        ->and(glob("{$directory}/*.tmp"))->toBe([]);
+});
 
 test('homeDirectory resolves HOME, then USERPROFILE, then HOMEDRIVE and HOMEPATH', function () {
     $this->setEnvironmentVariable('HOME', '/home/first/');

--- a/tests/Unit/FilesystemTest.php
+++ b/tests/Unit/FilesystemTest.php
@@ -54,6 +54,11 @@ test('homeDirectory returns null when no home variables are set', function () {
     expect(Filesystem::homeDirectory())->toBeNull();
 });
 
+test('relativePath strips the base and any leading slash', function () {
+    expect(Filesystem::relativePath('/home/user/.cpx/laravel/pint/latest', '/home/user/.cpx'))->toBe('laravel/pint/latest')
+        ->and(Filesystem::relativePath('C:\\Users\\u\\.cpx\\laravel\\pint\\latest', 'C:/Users/u/.cpx'))->toBe('laravel/pint/latest');
+});
+
 test('writeAtomic writes the full contents and leaves no temp residue', function () {
     $directory = $this->temporaryDirectory('cpx-fs');
     $path = "{$directory}/data.json";

--- a/tests/Unit/FilesystemTest.php
+++ b/tests/Unit/FilesystemTest.php
@@ -3,6 +3,31 @@
 use Composer\Util\Filesystem as ComposerFilesystem;
 use Cpx\Support\Filesystem;
 
+test('homeDirectory resolves HOME, then USERPROFILE, then HOMEDRIVE and HOMEPATH', function () {
+    $this->setEnvironmentVariable('HOME', '/home/first/');
+    $this->setEnvironmentVariable('USERPROFILE', 'C:\\Users\\second');
+    $this->setEnvironmentVariable('HOMEDRIVE', 'C:');
+    $this->setEnvironmentVariable('HOMEPATH', '\\Users\\third');
+
+    expect(Filesystem::homeDirectory())->toBe('/home/first');
+
+    $this->setEnvironmentVariable('HOME', '');
+
+    expect(Filesystem::homeDirectory())->toBe('C:\\Users\\second');
+
+    $this->setEnvironmentVariable('USERPROFILE', '');
+
+    expect(Filesystem::homeDirectory())->toBe('C:\\Users\\third');
+});
+
+test('homeDirectory returns null when no home variables are set', function () {
+    foreach (['HOME', 'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH'] as $variable) {
+        $this->setEnvironmentVariable($variable, '');
+    }
+
+    expect(Filesystem::homeDirectory())->toBeNull();
+});
+
 test('writeAtomic writes the full contents and leaves no temp residue', function () {
     $directory = $this->temporaryDirectory('cpx-fs');
     $path = "{$directory}/data.json";


### PR DESCRIPTION
## Overview

The Filesystem layer has some drift and a reliability gap: the home directory cascade is duplicated between local package parsing and the cpx cache path, `writeAtomic` fails outright when its final rename hits a transient lock (which happens on Windows when antivirus or another process briefly holds the target), and commands hand-roll their own cache-relative path rendering.

## Solution

The home directory lookup now lives in a single `Filesystem` method shared by both call sites, `writeAtomic` retries transient rename failures briefly before giving up, and cache-relative paths are rendered through one helper used by `clean` and `update`. A small filesystem fake makes the retry path testable deterministically.