### PR TITLE
Mechanical cleanups across the support and runtime layers

### DIFF
--- a/src/Commands/Concerns/OutputsJson.php
+++ b/src/Commands/Concerns/OutputsJson.php
@@ -12,11 +12,11 @@ trait OutputsJson
 {
     private function addJsonOption(): void
     {
-        $this->addOption('json', null, InputOption::VALUE_NONE, 'Output the result as JSON');
+        $this->addOption(Interactivity::JSON_OPTION, null, InputOption::VALUE_NONE, 'Output the result as JSON');
     }
 
     private function wantsJson(InputInterface $input): bool
     {
-        return $input->getOption('json') === true || ! Interactivity::isInteractive();
+        return $input->getOption(Interactivity::JSON_OPTION) === true || ! Interactivity::isInteractive();
     }
 }

--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -57,15 +57,13 @@ class ComposerRunner
      *
      * @throws ComposerCommandException
      */
-    public static function run(array $arguments, ?string $directory = null): int
+    public static function run(array $arguments, ?string $directory = null): void
     {
         $exitCode = self::execute($arguments, $directory, captureOutput: false)->exitCode;
 
         if ($exitCode !== Command::SUCCESS) {
             throw new ComposerCommandException($arguments);
         }
-
-        return $exitCode;
     }
 
     /**

--- a/src/Process/ProcessRunner.php
+++ b/src/Process/ProcessRunner.php
@@ -25,12 +25,12 @@ class ProcessRunner
 
     public static function withLogger(Logger $logger, callable $callback): mixed
     {
-        static::$logger = $logger;
+        self::$logger = $logger;
 
         try {
             return $callback();
         } finally {
-            static::$logger = null;
+            self::$logger = null;
         }
     }
 
@@ -92,7 +92,7 @@ class ProcessRunner
         try {
             $process = new Process($command, cwd: $cwd, env: $env === [] ? null : $env, timeout: null);
 
-            if (static::$logger !== null) {
+            if (self::$logger !== null) {
                 $output = '';
                 $exitCode = $process->run(function (string $type, string $buffer) use (&$output, $captureOutput): void {
                     if ($captureOutput) {
@@ -143,14 +143,14 @@ class ProcessRunner
 
     private function logOutput(string $type, string $buffer): void
     {
-        if (static::$logger === null) {
+        if (self::$logger === null) {
             return;
         }
 
         $message = rtrim($buffer);
 
         if ($message !== '') {
-            static::$logger->line($message);
+            self::$logger->line($message);
         }
     }
 

--- a/src/Runtime/SymfonyLoader.php
+++ b/src/Runtime/SymfonyLoader.php
@@ -62,10 +62,10 @@ class SymfonyLoader implements ProjectBooter
             return;
         }
 
-        $dotenv = new $dotenvClass;
+        $boot = [new $dotenvClass, 'bootEnv'];
 
-        if (is_object($dotenv) && method_exists($dotenv, 'bootEnv')) {
-            $dotenv->bootEnv("{$root}/.env");
+        if (is_callable($boot)) {
+            $boot("{$root}/.env");
         }
     }
 

--- a/src/Support/Interactivity.php
+++ b/src/Support/Interactivity.php
@@ -9,13 +9,17 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class Interactivity
 {
+    public const JSON_OPTION = 'json';
+
+    public const NON_INTERACTIVE_OPTIONS = ['--no-interaction', '-n', '--'.self::JSON_OPTION];
+
     private static ?bool $detected = null;
 
     private static ?bool $fakeEnvironment = null;
 
     public static function detect(InputInterface $input): void
     {
-        self::$detected = ! $input->hasParameterOption(['--no-interaction', '-n', '--json'], true)
+        self::$detected = ! $input->hasParameterOption(self::NON_INTERACTIVE_OPTIONS, true)
             && self::environmentIsInteractive();
     }
 

--- a/tests/Unit/ComposerRunnerTest.php
+++ b/tests/Unit/ComposerRunnerTest.php
@@ -29,7 +29,7 @@ test('it runs the require command', function () {
         ]);
 });
 
-test('it assembles arguments with no-interaction and working-dir and returns the runner exit code', function () {
+test('it assembles arguments with no-interaction and the working-dir option', function () {
     $captured = null;
     ComposerRunner::fake(function (array $command) use (&$captured): int {
         $captured = $command;
@@ -37,16 +37,15 @@ test('it assembles arguments with no-interaction and working-dir and returns the
         return 0;
     });
 
-    $exitCode = ComposerRunner::run(['require', 'vendor/package:^1@dev', '--no-progress'], '/tmp/example dir');
+    ComposerRunner::run(['require', 'vendor/package:^1@dev', '--no-progress'], '/tmp/example dir');
 
-    expect($exitCode)->toBe(0)
-        ->and($captured)->toBe([
-            'require',
-            'vendor/package:^1@dev',
-            '--no-progress',
-            '--no-interaction',
-            '--working-dir=/tmp/example dir',
-        ]);
+    expect($captured)->toBe([
+        'require',
+        'vendor/package:^1@dev',
+        '--no-progress',
+        '--no-interaction',
+        '--working-dir=/tmp/example dir',
+    ]);
 });
 
 test('it omits the working-dir option when no directory is given', function () {
@@ -208,11 +207,11 @@ test('it returns a non-zero exit code when the booted composer command fails', f
     expect(ComposerRunner::runInProcess(['this-command-does-not-exist', '--quiet'], new BufferedOutput))->toBe(1);
 });
 
-test('it runs an offline composer command in an isolated child process and returns success', function () {
+test('it runs an offline composer command in an isolated child process', function () {
     $this->useIsolatedComposerHome();
 
-    expect(ComposerRunner::run(['about', '--quiet']))->toBe(0);
-});
+    ComposerRunner::run(['about', '--quiet']);
+})->throwsNoExceptions();
 
 test('it throws the uniform message when an unknown composer command fails in the child', function () {
     $this->useIsolatedComposerHome();
@@ -225,10 +224,9 @@ test('it installs a package from a local path repository without network', funct
 
     $staging = $this->stagingWithPathPackages(['cpx-fixture/pkg']);
 
-    $exitCode = ComposerRunner::run(['require', 'cpx-fixture/pkg:*', '--quiet'], $staging);
+    ComposerRunner::run(['require', 'cpx-fixture/pkg:*', '--quiet'], $staging);
 
-    expect($exitCode)->toBe(0)
-        ->and(file_exists("{$staging}/vendor/autoload.php"))->toBeTrue()
+    expect(file_exists("{$staging}/vendor/autoload.php"))->toBeTrue()
         ->and(file_exists("{$staging}/vendor/cpx-fixture/pkg/composer.json"))->toBeTrue();
 });
 
@@ -261,10 +259,9 @@ test('it activates package plugins in the child without loading them into the cp
 
     ['staging' => $staging, 'package' => $package, 'pluginClass' => $pluginClass] = $this->stagingWithPluginPackage();
 
-    $exitCode = ComposerRunner::run(['require', "{$package}:*", '--quiet'], $staging);
+    ComposerRunner::run(['require', "{$package}:*", '--quiet'], $staging);
 
-    expect($exitCode)->toBe(0)
-        ->and(file_exists("{$staging}/vendor/{$package}/composer.json"))->toBeTrue()
+    expect(file_exists("{$staging}/vendor/{$package}/composer.json"))->toBeTrue()
         ->and(class_exists($pluginClass, autoload: false))->toBeFalse();
 });
 

--- a/tests/Unit/InteractivityTest.php
+++ b/tests/Unit/InteractivityTest.php
@@ -3,6 +3,10 @@
 use Cpx\Support\Interactivity;
 use Symfony\Component\Console\Input\ArgvInput;
 
+test('the json flag list shares one source with non-interactive detection', function () {
+    expect(Interactivity::NON_INTERACTIVE_OPTIONS)->toContain('--'.Interactivity::JSON_OPTION);
+});
+
 test('an agent environment is non-interactive', function () {
     Interactivity::clearFake();
     $this->setEnvironmentVariable('AI_AGENT', 'test-agent');


### PR DESCRIPTION
## Overview

A few small inconsistencies have accumulated: the `--json` flag is spelled in two unrelated places that must stay in sync, `ComposerRunner::run()` declares an exit code that can only ever be success because every failure throws, and `ProcessRunner` mixes `static::` and `self::` for its private statics while `SymfonyLoader` probes the dotenv class more verbosely than needed.

## Solution

The interactivity detection and the JSON commands now share one flag constant, `ComposerRunner::run()` returns void so callers rely on the exception contract, and the `ProcessRunner`/`SymfonyLoader` internals get the mechanical tidy-up. No behavior changes.