### PR TITLE
Pin the PHAR build and point metadata at laravel/cpx

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: imliam

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 /builds/box-*.phar
+*.bak

--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ No. cpx ships as a self-contained PHAR with its own runtime dependencies bundled
 ## Credits
 
 - [Liam Hammett](https://github.com/imliam)
-- [All Contributors](https://github.com/imliam/cpx/contributors)
+- [All Contributors](https://github.com/laravel/cpx/contributors)

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "run"
     ],
     "support": {
-        "issues": "https://github.com/imliam/cpx/issues",
-        "source": "https://github.com/imliam/cpx",
+        "issues": "https://github.com/laravel/cpx/issues",
+        "source": "https://github.com/laravel/cpx",
         "docs": "https://cpx.dev"
     },
     "authors": [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -92,7 +92,13 @@ if [ ! -f "$BOX_PHAR" ]; then
     mv "${BOX_PHAR}.tmp" "$BOX_PHAR"
 fi
 
-if ! echo "${BOX_SHA256}  ${BOX_PHAR}" | sha256sum -c --status -; then
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA256_CMD="sha256sum"
+else
+    SHA256_CMD="shasum -a 256"
+fi
+
+if ! echo "${BOX_SHA256}  ${BOX_PHAR}" | $SHA256_CMD -c --status -; then
     rm -f "$BOX_PHAR"
     echo "Box ${BOX_VERSION} failed the sha256 check; expected ${BOX_SHA256}. The download was discarded." >&2
     exit 1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,6 +16,7 @@ COMPOSER_LOCK_BACKUP=""
 
 # The pinned copy is cached under builds/ (gitignored) and only downloaded once.
 BOX_VERSION="4.7.0"
+BOX_SHA256="3d390eeaec33288098fe83f8a54c60cc575cb6be295f38ff4482b4b4f26f8d52"
 BOX_URL="https://github.com/box-project/box/releases/download/${BOX_VERSION}/box.phar"
 BOX_PHAR="builds/box-${BOX_VERSION}.phar"
 
@@ -33,14 +34,20 @@ success() {
 
 cleanup() {
     # Restore anything we swapped out if the build was interrupted mid-flight.
+    restored=0
     if [ -n "$VERSION_BACKUP" ] && [ -f "$VERSION_BACKUP" ]; then
         mv "$VERSION_BACKUP" "$VERSION_FILE"
     fi
     if [ -n "$COMPOSER_JSON_BACKUP" ] && [ -f "$COMPOSER_JSON_BACKUP" ]; then
         mv "$COMPOSER_JSON_BACKUP" composer.json
+        restored=1
     fi
     if [ -n "$COMPOSER_LOCK_BACKUP" ] && [ -f "$COMPOSER_LOCK_BACKUP" ]; then
         mv "$COMPOSER_LOCK_BACKUP" composer.lock
+        restored=1
+    fi
+    if [ "$restored" -eq 1 ]; then
+        echo "Restored composer.json and composer.lock; run \`composer install\` to reinstall dev dependencies." >&2
     fi
 }
 trap cleanup EXIT
@@ -56,12 +63,21 @@ cp composer.lock "$COMPOSER_LOCK_BACKUP"
 php -r '
     $path = "composer.json";
     $data = json_decode(file_get_contents($path), true);
+    $lock = json_decode(file_get_contents("composer.lock"), true);
+    $locked = [];
+    foreach (array_merge($lock["packages"] ?? [], $lock["packages-dev"] ?? []) as $package) {
+        $locked[$package["name"]] = $package["version"];
+    }
     foreach (array_slice($argv, 1) as $package) {
         if (! isset($data["require-dev"][$package])) {
             fwrite(STDERR, "Runtime package not found in require-dev: {$package}\n");
             exit(1);
         }
-        $data["require"][$package] = $data["require-dev"][$package];
+        if (! isset($locked[$package])) {
+            fwrite(STDERR, "Runtime package not found in composer.lock: {$package}\n");
+            exit(1);
+        }
+        $data["require"][$package] = $locked[$package];
     }
     unset($data["require-dev"]);
     file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
@@ -74,6 +90,12 @@ if [ ! -f "$BOX_PHAR" ]; then
     mkdir -p builds
     curl -sSL -o "${BOX_PHAR}.tmp" "$BOX_URL"
     mv "${BOX_PHAR}.tmp" "$BOX_PHAR"
+fi
+
+if ! echo "${BOX_SHA256}  ${BOX_PHAR}" | sha256sum -c --status -; then
+    rm -f "$BOX_PHAR"
+    echo "Box ${BOX_VERSION} failed the sha256 check; expected ${BOX_SHA256}. The download was discarded." >&2
+    exit 1
 fi
 
 if [ -n "$VERSION" ]; then


### PR DESCRIPTION
## Overview

The PHAR build resolves its runtime packages with loose constraints, so two builds from the same commit can bundle different dependency versions, and it downloads Box without verifying what it fetched. Meanwhile, parts of the project metadata still point at the old imliam/cpx repository.

## Solution

The build script now installs runtime packages at the exact versions recorded in `composer.lock` and verifies the Box phar against a pinned sha256 before using it, and the support links, contributors link, and funding file now reflect the move to laravel/cpx.