### PR TITLE
Fix missing-package detection for long package names

### DIFF
--- a/src/Composer/ComposerRunner.php
+++ b/src/Composer/ComposerRunner.php
@@ -164,8 +164,9 @@ class ComposerRunner
         $runner = new ProcessRunner;
         $processCommand = [...self::composerBinary(), ...$command];
 
+        // A wide COLUMNS keeps wrapped package names from defeating missingPackage()
         return $captureOutput
-            ? $runner->runWithOutput($processCommand)
+            ? $runner->runWithOutput($processCommand, ['COLUMNS' => '4096'])
             : new ProcessResult($runner->run($processCommand), '');
     }
 

--- a/tests/Unit/ComposerRunnerTest.php
+++ b/tests/Unit/ComposerRunnerTest.php
@@ -138,6 +138,16 @@ test('it identifies a real composer missing-package diagnostic', function () {
     );
 })->throws(PackageNotFoundException::class);
 
+test('it identifies a real missing package whose long name wraps in the error output', function () {
+    $this->useIsolatedComposerHome();
+    $staging = $this->stagingWithPathPackages(['cpx-fixture/available']);
+
+    ProcessRunner::withLogger(
+        new SilentLogger,
+        fn () => ComposerRunner::require('cpx-fixture/a-really-long-missing-package-name-that-composer-wraps', $staging),
+    );
+})->throws(PackageNotFoundException::class);
+
 test('it identifies a real missing transitive dependency', function () {
     $this->useIsolatedComposerHome();
 


### PR DESCRIPTION
## Overview

Running a missing package with a long name shows the generic `Composer command failed: require …` error instead of the package-not-found message. Composer wraps its boxed error output at the terminal width, so long package names get split across lines and `missingPackage()` never matches them.

## Solution

Run captured composer commands with a wide `COLUMNS` so the child's error renderer never wraps and package names stay intact for detection. A real-composer regression test covers a package name long enough to wrap.