### PR TITLE
Add a bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report something that is not working as expected.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please complete the fields below so we can reproduce the issue quickly.
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Package Version
+      description: Provide the package version that you are using.
+      placeholder: 1.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: laravel-version
+    attributes:
+      label: Laravel Version
+      description: Provide the Laravel version that you are using.
+      placeholder: 13.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP Version
+      description: Provide the PHP version that you are using.
+      placeholder: 8.3.0
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating System
+      description: If relevant, provide the operating system and version where this occurs.
+      placeholder: macOS 15.0, Ubuntu 24.04, Windows 11
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear description of the issue you are facing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Provide detailed steps to reproduce the issue. A minimal reproduction repository is helpful when possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Add any other context that might help diagnose the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,20 +9,11 @@ body:
         Thanks for taking the time to report a bug. Please complete the fields below so we can reproduce the issue quickly.
 
   - type: input
-    id: package-version
+    id: cpx-version
     attributes:
-      label: Package Version
-      description: Provide the package version that you are using.
-      placeholder: 1.0.0
-    validations:
-      required: true
-
-  - type: input
-    id: laravel-version
-    attributes:
-      label: Laravel Version
-      description: Provide the Laravel version that you are using.
-      placeholder: 13.0.0
+      label: cpx Version
+      description: Provide the cpx version that you are using.
+      placeholder: 2.0.0
     validations:
       required: true
 
@@ -39,10 +30,10 @@ body:
     id: operating-system
     attributes:
       label: Operating System
-      description: If relevant, provide the operating system and version where this occurs.
+      description: Provide the operating system and version where this occurs.
       placeholder: macOS 15.0, Ubuntu 24.04, Windows 11
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: description


### PR DESCRIPTION
## Overview

The repo has no issue template, so bug reports arrive as free-form text and often miss the basics needed to reproduce them, like the cpx version or the reporter's operating system.

## Solution

Add a GitHub issue form for bug reports: it requires the cpx version, PHP version, and operating system, plus a description and reproduction steps.