### PR TITLE
[2.x] Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,7 @@
 .github/ export-ignore
 .gitignore export-ignore
 banner-v2.png export-ignore
+phpstan.neon.dist export-ignore
+pint.json export-ignore
 README.md export-ignore
+/tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,15 @@
 * text=auto eol=lf
 
-.gitattributes export-ignore
-.github/ export-ignore
-.gitignore export-ignore
-banner-v2.png export-ignore
-phpstan.neon.dist export-ignore
-pint.json export-ignore
-README.md export-ignore
-/tests export-ignore
+/.gitattributes     export-ignore
+/.github            export-ignore
+/.gitignore         export-ignore
+/banner-v2.png      export-ignore
+/box.json           export-ignore
+/composer.lock      export-ignore
+/cpx                export-ignore
+/phpstan.neon.dist  export-ignore
+/phpunit.xml        export-ignore
+/pint.json          export-ignore
+/README.md          export-ignore
+/scripts            export-ignore
+/tests              export-ignore


### PR DESCRIPTION
[Wazuppp](https://youtu.be/A3oL7v7PLac?t=21)

bored, passing thru and updating these git attributes, it export ignores `phpstan.neon.dist`, `pint.json` and the `/tests` dir 

Should avoid them being in global vendor then when we do `composer global require xyz` 

So, I think this PR is valid? Otherwise lmk what I did wrong (there could be more to ignore, but not familiar with box too much, so didnt wanna cause a b/c) 