### PR TITLE
Add a self-update command for the standalone PHAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Upgrade to the latest release at any time by running:
 composer global update cpx/cpx
 ```
 
+If you run the standalone PHAR instead, cpx can update itself in place by downloading the latest release from GitHub:
+
+```bash
+cpx self-update
+```
+
 ## Usage
 
 You can run a command using cpx by passing through the package name and the command you want to run:

--- a/src/Application.php
+++ b/src/Application.php
@@ -11,6 +11,7 @@ use Cpx\Commands\ExecCommand;
 use Cpx\Commands\InstalledCommand;
 use Cpx\Commands\RunPackageCommand;
 use Cpx\Commands\SandboxCommand;
+use Cpx\Commands\SelfUpdateCommand;
 use Cpx\Commands\TinkerCommand;
 use Cpx\Commands\UnaliasCommand;
 use Cpx\Commands\UpdateCommand;
@@ -101,6 +102,7 @@ class Application extends SymfonyApplication
             new UnaliasCommand,
             new CleanCommand,
             new UpdateCommand,
+            new SelfUpdateCommand,
             new ExecCommand,
             new TinkerCommand,
             new SandboxCommand,

--- a/src/Commands/SelfUpdateCommand.php
+++ b/src/Commands/SelfUpdateCommand.php
@@ -81,7 +81,7 @@ class SelfUpdateCommand extends Command
             return self::SUCCESS;
         } catch (SelfUpdateException $exception) {
             if (! Interactivity::isInteractive()) {
-                return Result::failure($output, $exception->getMessage());
+                return Result::failure($output, $exception->messages());
             }
 
             $exception->render();

--- a/src/Commands/SelfUpdateCommand.php
+++ b/src/Commands/SelfUpdateCommand.php
@@ -13,10 +13,12 @@ use Cpx\SelfUpdate\Release;
 use Cpx\SelfUpdate\ReleaseClient;
 use Cpx\Support\Filesystem;
 use Cpx\Support\Interactivity;
+use Cpx\Support\JsonEnvelope;
 use Cpx\Support\Result;
 use Cpx\Support\SilentLogger;
 use Cpx\Version;
-use Laravel\Prompts\Support\Logger;
+use Laravel\Prompts\Output\BufferedConsoleOutput;
+use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,7 +26,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\callout;
 use function Laravel\Prompts\info;
-use function Laravel\Prompts\task;
 
 #[AsCommand(
     name: 'self-update',
@@ -63,7 +64,17 @@ class SelfUpdateCommand extends Command
                 return $this->reportAlreadyLatest($output, $current, $json);
             }
 
-            $this->applyUpdate($release, $target, $json);
+            if (! $json) {
+                info("Downloading cpx {$release->tag}...");
+            }
+
+            $this->warmReportingClasses($output, $current, $release, $target, $json);
+
+            ProcessRunner::withLogger(new SilentLogger, fn () => $this->replacer->replace(
+                $target,
+                $release,
+                fn (string $destination) => $this->releases->download($release, $destination),
+            ));
 
             return $this->reportUpdated($output, $current, $release, $target, $json);
         } catch (SelfUpdateException $exception) {
@@ -77,35 +88,24 @@ class SelfUpdateCommand extends Command
         }
     }
 
-    /** @throws SelfUpdateException */
-    private function applyUpdate(Release $release, string $target, bool $json): void
+    /** The running phar cannot autoload after its file is swapped, so preload everything the report touches. */
+    private function warmReportingClasses(OutputInterface $output, string $current, Release $release, string $target, bool $json): void
     {
-        $download = fn (string $destination) => $this->releases->download($release, $destination);
+        class_exists(SelfUpdateException::class);
 
         if ($json) {
-            ProcessRunner::withLogger(new SilentLogger, fn () => $this->replacer->replace($target, $release, $download));
+            class_exists(Result::class);
+            class_exists(JsonEnvelope::class);
 
             return;
         }
 
-        $failure = null;
+        Prompt::setOutput(new BufferedConsoleOutput);
 
-        task(
-            label: "Updating cpx to {$release->tag}",
-            callback: function (Logger $logger) use ($release, $target, $download, &$failure): void {
-                try {
-                    ProcessRunner::withLogger($logger, fn () => $this->replacer->replace($target, $release, $download));
-                    $logger->label("cpx was updated to {$release->tag}");
-                } catch (SelfUpdateException $exception) {
-                    $failure = $exception;
-                    $logger->label('cpx could not be updated');
-                }
-            },
-            keepSummary: true,
-        );
-
-        if ($failure !== null) {
-            throw $failure;
+        try {
+            $this->renderUpdatedCallout($current, $release, $target);
+        } finally {
+            Prompt::setOutput($output);
         }
     }
 
@@ -126,6 +126,13 @@ class SelfUpdateCommand extends Command
             return Result::success($output, ['updated' => true, 'from' => $current, 'to' => $release->tag, 'path' => $target]);
         }
 
+        $this->renderUpdatedCallout($current, $release, $target);
+
+        return self::SUCCESS;
+    }
+
+    private function renderUpdatedCallout(string $current, Release $release, string $target): void
+    {
         $content = ["Updated cpx from {$current} to {$release->tag}."];
 
         if (str_contains(Filesystem::normalizePath($target), '/vendor/cpx/cpx/')) {
@@ -134,7 +141,5 @@ class SelfUpdateCommand extends Command
         }
 
         callout(label: 'cpx updated', content: $content);
-
-        return self::SUCCESS;
     }
 }

--- a/src/Commands/SelfUpdateCommand.php
+++ b/src/Commands/SelfUpdateCommand.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Commands;
+
+use Cpx\Commands\Concerns\OutputsJson;
+use Cpx\Exceptions\SelfUpdateException;
+use Cpx\Process\ProcessRunner;
+use Cpx\Runtime\Environment;
+use Cpx\SelfUpdate\PharReplacer;
+use Cpx\SelfUpdate\Release;
+use Cpx\SelfUpdate\ReleaseClient;
+use Cpx\Support\Filesystem;
+use Cpx\Support\Interactivity;
+use Cpx\Support\Result;
+use Cpx\Support\SilentLogger;
+use Cpx\Version;
+use Laravel\Prompts\Support\Logger;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\callout;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\task;
+
+#[AsCommand(
+    name: 'self-update',
+    description: 'Update cpx to the latest version',
+)]
+class SelfUpdateCommand extends Command
+{
+    use OutputsJson;
+
+    public function __construct(
+        private readonly ReleaseClient $releases = new ReleaseClient,
+        private readonly PharReplacer $replacer = new PharReplacer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addJsonOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $json = $this->wantsJson($input);
+        $current = Version::resolve();
+
+        try {
+            if (! Environment::isPhar()) {
+                throw SelfUpdateException::notRunningFromPhar();
+            }
+
+            $target = Environment::pharPath();
+            $release = $this->releases->latest();
+
+            if ($release->tag === $current) {
+                return $this->reportAlreadyLatest($output, $current, $json);
+            }
+
+            $this->applyUpdate($release, $target, $json);
+
+            return $this->reportUpdated($output, $current, $release, $target, $json);
+        } catch (SelfUpdateException $exception) {
+            if (! Interactivity::isInteractive()) {
+                return Result::failure($output, $exception->getMessage());
+            }
+
+            $exception->render();
+
+            return self::FAILURE;
+        }
+    }
+
+    /** @throws SelfUpdateException */
+    private function applyUpdate(Release $release, string $target, bool $json): void
+    {
+        $download = fn (string $destination) => $this->releases->download($release, $destination);
+
+        if ($json) {
+            ProcessRunner::withLogger(new SilentLogger, fn () => $this->replacer->replace($target, $release, $download));
+
+            return;
+        }
+
+        $failure = null;
+
+        task(
+            label: "Updating cpx to {$release->tag}",
+            callback: function (Logger $logger) use ($release, $target, $download, &$failure): void {
+                try {
+                    ProcessRunner::withLogger($logger, fn () => $this->replacer->replace($target, $release, $download));
+                    $logger->label("cpx was updated to {$release->tag}");
+                } catch (SelfUpdateException $exception) {
+                    $failure = $exception;
+                    $logger->label('cpx could not be updated');
+                }
+            },
+            keepSummary: true,
+        );
+
+        if ($failure !== null) {
+            throw $failure;
+        }
+    }
+
+    private function reportAlreadyLatest(OutputInterface $output, string $current, bool $json): int
+    {
+        if ($json) {
+            return Result::success($output, ['updated' => false, 'version' => $current]);
+        }
+
+        info("cpx {$current} is already the latest version.");
+
+        return self::SUCCESS;
+    }
+
+    private function reportUpdated(OutputInterface $output, string $current, Release $release, string $target, bool $json): int
+    {
+        if ($json) {
+            return Result::success($output, ['updated' => true, 'from' => $current, 'to' => $release->tag, 'path' => $target]);
+        }
+
+        $content = ["Updated cpx from {$current} to {$release->tag}."];
+
+        if (str_contains(Filesystem::normalizePath($target), '/vendor/cpx/cpx/')) {
+            $content[] = 'This copy of cpx is managed by Composer.';
+            $content[] = "Run 'composer global update cpx/cpx' to persist this update.";
+        }
+
+        callout(label: 'cpx updated', content: $content);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/SelfUpdateCommand.php
+++ b/src/Commands/SelfUpdateCommand.php
@@ -61,7 +61,7 @@ class SelfUpdateCommand extends Command
             $release = $this->releases->latest();
 
             if ($release->tag === $current) {
-                return $this->reportAlreadyLatest($output, $current, $json);
+                return $this->reportAlreadyLatest($output, $current, $target, $json);
             }
 
             if (! $json) {
@@ -104,7 +104,7 @@ class SelfUpdateCommand extends Command
         $buffer->setDecorated($output->isDecorated());
 
         if ($json) {
-            Result::success($buffer, ['updated' => true, 'from' => $current, 'to' => $release->tag, 'path' => $target]);
+            Result::success($buffer, $this->summary(true, $current, $release->tag, $target));
 
             return $buffer->fetch();
         }
@@ -120,15 +120,25 @@ class SelfUpdateCommand extends Command
         return $buffer->fetch();
     }
 
-    private function reportAlreadyLatest(OutputInterface $output, string $current, bool $json): int
+    private function reportAlreadyLatest(OutputInterface $output, string $current, string $target, bool $json): int
     {
         if ($json) {
-            return Result::success($output, ['updated' => false, 'version' => $current]);
+            return Result::success($output, $this->summary(false, $current, $current, $target));
         }
 
         info("cpx {$current} is already the latest version.");
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Both outcomes report the same keys so consumers never have to branch on which are present.
+     *
+     * @return array<string, mixed>
+     */
+    private function summary(bool $updated, string $from, string $to, string $target): array
+    {
+        return ['updated' => $updated, 'from' => $from, 'to' => $to, 'path' => $target];
     }
 
     private function renderUpdatedCallout(string $current, Release $release, string $target): void

--- a/src/Commands/SelfUpdateCommand.php
+++ b/src/Commands/SelfUpdateCommand.php
@@ -68,7 +68,7 @@ class SelfUpdateCommand extends Command
                 info("Downloading cpx {$release->tag}...");
             }
 
-            $this->warmReportingClasses($output, $current, $release, $target, $json);
+            $report = $this->renderUpdated($output, $current, $release, $target, $json);
 
             ProcessRunner::withLogger(new SilentLogger, fn () => $this->replacer->replace(
                 $target,
@@ -76,7 +76,9 @@ class SelfUpdateCommand extends Command
                 fn (string $destination) => $this->releases->download($release, $destination),
             ));
 
-            return $this->reportUpdated($output, $current, $release, $target, $json);
+            $output->write($report, false, OutputInterface::OUTPUT_RAW);
+
+            return self::SUCCESS;
         } catch (SelfUpdateException $exception) {
             if (! Interactivity::isInteractive()) {
                 return Result::failure($output, $exception->getMessage());
@@ -88,25 +90,34 @@ class SelfUpdateCommand extends Command
         }
     }
 
-    /** The running phar cannot autoload after its file is swapped, so preload everything the report touches. */
-    private function warmReportingClasses(OutputInterface $output, string $current, Release $release, string $target, bool $json): void
+    /**
+     * The running phar cannot autoload after its file is swapped, so the report is rendered before
+     * the swap and only written out afterwards. Rendering also loads what a late failure reports.
+     */
+    private function renderUpdated(OutputInterface $output, string $current, Release $release, string $target, bool $json): string
     {
         class_exists(SelfUpdateException::class);
+        class_exists(Result::class);
+        class_exists(JsonEnvelope::class);
+
+        $buffer = new BufferedConsoleOutput;
+        $buffer->setDecorated($output->isDecorated());
 
         if ($json) {
-            class_exists(Result::class);
-            class_exists(JsonEnvelope::class);
+            Result::success($buffer, ['updated' => true, 'from' => $current, 'to' => $release->tag, 'path' => $target]);
 
-            return;
+            return $buffer->fetch();
         }
 
-        Prompt::setOutput(new BufferedConsoleOutput);
+        Prompt::setOutput($buffer);
 
         try {
             $this->renderUpdatedCallout($current, $release, $target);
         } finally {
             Prompt::setOutput($output);
         }
+
+        return $buffer->fetch();
     }
 
     private function reportAlreadyLatest(OutputInterface $output, string $current, bool $json): int
@@ -116,17 +127,6 @@ class SelfUpdateCommand extends Command
         }
 
         info("cpx {$current} is already the latest version.");
-
-        return self::SUCCESS;
-    }
-
-    private function reportUpdated(OutputInterface $output, string $current, Release $release, string $target, bool $json): int
-    {
-        if ($json) {
-            return Result::success($output, ['updated' => true, 'from' => $current, 'to' => $release->tag, 'path' => $target]);
-        }
-
-        $this->renderUpdatedCallout($current, $release, $target);
 
         return self::SUCCESS;
     }

--- a/src/Exceptions/SelfUpdateException.php
+++ b/src/Exceptions/SelfUpdateException.php
@@ -23,9 +23,15 @@ class SelfUpdateException extends Exception
     {
         callout(
             label: $this->label,
-            content: [$this->getMessage(), ...$this->details],
+            content: $this->messages(),
             type: 'error',
         );
+    }
+
+    /** @return list<string> */
+    public function messages(): array
+    {
+        return [$this->getMessage(), ...$this->details];
     }
 
     public static function notRunningFromPhar(): self

--- a/src/Exceptions/SelfUpdateException.php
+++ b/src/Exceptions/SelfUpdateException.php
@@ -97,10 +97,13 @@ class SelfUpdateException extends Exception
         ]);
     }
 
-    public static function swapFailed(string $path): self
+    public static function swapFailed(string $path, ?string $backup = null): self
     {
-        return new self("Unable to replace the cpx PHAR at '{$path}'.", 'Self-update failed', [
-            'The previous PHAR was restored.',
+        return new self("Unable to replace the cpx PHAR at '{$path}'.", 'Self-update failed', $backup === null ? [
+            'The previous PHAR was left in place.',
+        ] : [
+            'The previous PHAR could not be restored automatically.',
+            "A backup was kept at '{$backup}'.",
         ]);
     }
 }

--- a/src/Exceptions/SelfUpdateException.php
+++ b/src/Exceptions/SelfUpdateException.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\Exceptions;
+
+use Exception;
+
+use function Laravel\Prompts\callout;
+
+class SelfUpdateException extends Exception
+{
+    /** @param list<string> $details */
+    public function __construct(
+        string $message,
+        private readonly string $label = 'Self-update failed',
+        private readonly array $details = [],
+    ) {
+        parent::__construct($message);
+    }
+
+    public function render(): void
+    {
+        callout(
+            label: $this->label,
+            content: [$this->getMessage(), ...$this->details],
+            type: 'error',
+        );
+    }
+
+    public static function notRunningFromPhar(): self
+    {
+        return new self('self-update is only available when cpx is running as a PHAR.', 'Self-update unavailable', [
+            'Update a Composer-managed installation with:',
+            'composer global update cpx/cpx',
+        ]);
+    }
+
+    public static function releaseFetchFailed(string $url, ?int $status = null): self
+    {
+        return new self(
+            "Unable to fetch the latest cpx release from '{$url}'.",
+            'Self-update failed',
+            $status === null ? [] : ["GitHub responded with HTTP status {$status}."],
+        );
+    }
+
+    public static function invalidToken(): self
+    {
+        return new self('GitHub rejected the provided GITHUB_TOKEN.', 'GitHub authentication failed', [
+            'Check that the GITHUB_TOKEN environment variable holds a valid token.',
+        ]);
+    }
+
+    public static function rateLimited(): self
+    {
+        return new self('GitHub rate limit exceeded while checking for a new cpx version.', 'GitHub rate limit', [
+            'Set the GITHUB_TOKEN environment variable to authenticate and raise the limit.',
+        ]);
+    }
+
+    public static function invalidResponse(): self
+    {
+        return new self('Unexpected response from the GitHub releases API.');
+    }
+
+    public static function assetNotFound(string $tag): self
+    {
+        return new self("The latest release ({$tag}) does not include a cpx PHAR asset.", 'Self-update failed', [
+            'Download cpx manually from https://github.com/laravel/cpx/releases.',
+        ]);
+    }
+
+    public static function unwritableTemporaryFile(string $file): self
+    {
+        return new self("Unable to write the downloaded PHAR to '{$file}'.");
+    }
+
+    public static function checksumMismatch(): self
+    {
+        return new self('The downloaded PHAR does not match the sha256 checksum GitHub published.', 'Self-update failed', [
+            "Run 'cpx self-update' again to retry the download.",
+        ]);
+    }
+
+    public static function validationFailed(string $tag): self
+    {
+        return new self("The downloaded PHAR did not report version {$tag} when executed.", 'Self-update failed', [
+            "Run 'cpx self-update' again to retry the download.",
+        ]);
+    }
+
+    public static function notWritable(string $path): self
+    {
+        return new self("The cpx PHAR at '{$path}' cannot be replaced.", 'Self-update failed', [
+            'Check the file permissions or rerun the command with elevated privileges.',
+        ]);
+    }
+
+    public static function swapFailed(string $path): self
+    {
+        return new self("Unable to replace the cpx PHAR at '{$path}'.", 'Self-update failed', [
+            'The previous PHAR was restored.',
+        ]);
+    }
+}

--- a/src/SelfUpdate/PharReplacer.php
+++ b/src/SelfUpdate/PharReplacer.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\SelfUpdate;
+
+use Closure;
+use Cpx\Exceptions\SelfUpdateException;
+use Cpx\Process\ProcessRunner;
+use Cpx\Support\Filesystem;
+use RuntimeException;
+
+class PharReplacer
+{
+    public function __construct(
+        private readonly ProcessRunner $processes = new ProcessRunner,
+        private readonly bool $windows = PHP_OS_FAMILY === 'Windows',
+    ) {
+        //
+    }
+
+    /**
+     * @param  Closure(string): void  $download  Writes the new PHAR to the given path.
+     *
+     * @throws SelfUpdateException
+     */
+    public function replace(string $target, Release $release, Closure $download): void
+    {
+        $directory = dirname($target);
+
+        if (! is_writable($directory) || ($this->windows && ! is_writable($target))) {
+            throw SelfUpdateException::notWritable($target);
+        }
+
+        $temporary = $this->workingPath($target, 'tmp');
+
+        try {
+            $download($temporary);
+            $this->verifyChecksum($temporary, $release);
+            $this->verifyRuns($temporary, $release);
+        } catch (SelfUpdateException $exception) {
+            $this->cleanup($temporary);
+
+            throw $exception;
+        }
+
+        $permissions = fileperms($target);
+        @chmod($temporary, $permissions === false ? 0755 : $permissions & 0777);
+
+        $this->swap($temporary, $target);
+    }
+
+    /** @throws SelfUpdateException */
+    private function verifyChecksum(string $temporary, Release $release): void
+    {
+        if ($release->sha256 === null) {
+            return;
+        }
+
+        $actual = hash_file('sha256', $temporary);
+
+        if ($actual === false || ! hash_equals($release->sha256, $actual)) {
+            throw SelfUpdateException::checksumMismatch();
+        }
+    }
+
+    /** @throws SelfUpdateException */
+    private function verifyRuns(string $temporary, Release $release): void
+    {
+        $result = $this->processes->runWithOutput([PHP_BINARY, $temporary, '--version']);
+
+        if ($result->exitCode !== 0 || ! str_contains($result->output, $release->tag)) {
+            throw SelfUpdateException::validationFailed($release->tag);
+        }
+    }
+
+    /** @throws SelfUpdateException */
+    private function swap(string $temporary, string $target): void
+    {
+        $backup = $this->workingPath($target, 'backup');
+
+        if (! @copy($target, $backup)) {
+            $this->cleanup($temporary);
+
+            throw SelfUpdateException::swapFailed($target);
+        }
+
+        try {
+            Filesystem::replaceFile($temporary, $target, viaCopy: $this->windows);
+        } catch (RuntimeException) {
+            @copy($backup, $target);
+            $this->cleanup($temporary, $backup);
+
+            throw SelfUpdateException::swapFailed($target);
+        }
+
+        $this->cleanup($backup);
+    }
+
+    private function workingPath(string $target, string $suffix): string
+    {
+        return $target.'.'.bin2hex(random_bytes(8)).'.'.$suffix;
+    }
+
+    private function cleanup(string ...$paths): void
+    {
+        foreach ($paths as $path) {
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+    }
+}

--- a/src/SelfUpdate/PharReplacer.php
+++ b/src/SelfUpdate/PharReplacer.php
@@ -32,6 +32,8 @@ class PharReplacer
             throw SelfUpdateException::notWritable($target);
         }
 
+        $this->removeStaleWorkingFiles($directory, basename($target));
+
         $temporary = $this->workingPath($target, 'tmp');
 
         try {
@@ -88,18 +90,30 @@ class PharReplacer
         try {
             Filesystem::replaceFile($temporary, $target, viaCopy: $this->windows);
         } catch (RuntimeException) {
-            @copy($backup, $target);
-            $this->cleanup($temporary, $backup);
+            $restored = @copy($backup, $target);
+            $this->cleanup(...($restored ? [$temporary, $backup] : [$temporary]));
 
-            throw SelfUpdateException::swapFailed($target);
+            throw SelfUpdateException::swapFailed($target, $restored ? null : $backup);
         }
 
-        $this->cleanup($backup);
+        $this->cleanup($temporary, $backup);
     }
 
     private function workingPath(string $target, string $suffix): string
     {
         return $target.'.'.bin2hex(random_bytes(8)).'.'.$suffix;
+    }
+
+    /** Working files from a crashed earlier run have unpredictable names, so sweep them before starting. */
+    private function removeStaleWorkingFiles(string $directory, string $basename): void
+    {
+        $pattern = '/\A'.preg_quote($basename, '/').'\.[0-9a-f]{16}\.(tmp|backup)\z/';
+
+        foreach (@scandir($directory) ?: [] as $entry) {
+            if (preg_match($pattern, $entry) === 1) {
+                @unlink("{$directory}/{$entry}");
+            }
+        }
     }
 
     private function cleanup(string ...$paths): void

--- a/src/SelfUpdate/Release.php
+++ b/src/SelfUpdate/Release.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\SelfUpdate;
+
+readonly class Release
+{
+    public function __construct(
+        public string $tag,
+        public string $downloadUrl,
+        public ?string $sha256 = null,
+    ) {
+        //
+    }
+}

--- a/src/SelfUpdate/ReleaseClient.php
+++ b/src/SelfUpdate/ReleaseClient.php
@@ -6,6 +6,7 @@ namespace Cpx\SelfUpdate;
 
 use Closure;
 use Cpx\Exceptions\SelfUpdateException;
+use RuntimeException;
 
 class ReleaseClient
 {
@@ -31,7 +32,7 @@ class ReleaseClient
 
         $payload = json_decode($this->httpGet(self::LATEST_RELEASE_ENDPOINT), true);
 
-        if (! is_array($payload) || ! is_string($payload['tag_name'] ?? null)) {
+        if (! is_array($payload) || ! is_string($payload['tag_name'] ?? null) || $payload['tag_name'] === '') {
             throw SelfUpdateException::invalidResponse();
         }
 
@@ -49,7 +50,13 @@ class ReleaseClient
             return;
         }
 
-        if (@file_put_contents($destination, $this->httpGet($release->downloadUrl)) === false) {
+        if (self::$fakeLatest !== null) {
+            throw new RuntimeException('ReleaseClient::fake() requires a download handler when download() is used.');
+        }
+
+        $content = $this->httpGet($release->downloadUrl);
+
+        if (@file_put_contents($destination, $content) !== strlen($content)) {
             throw SelfUpdateException::unwritableTemporaryFile($destination);
         }
     }
@@ -98,6 +105,8 @@ class ReleaseClient
                 'header' => implode("\r\n", $this->requestHeaders($url)),
                 'timeout' => $this->timeout,
                 'ignore_errors' => true,
+                // The wrapper resends all headers on redirects, so token-bearing API requests must not follow them.
+                'follow_location' => $this->isApiRequest($url) ? 0 : 1,
             ],
         ]);
 
@@ -129,11 +138,16 @@ class ReleaseClient
 
         $token = $_SERVER['GITHUB_TOKEN'] ?? getenv('GITHUB_TOKEN');
 
-        if (is_string($token) && $token !== '' && str_starts_with($url, 'https://api.github.com/')) {
+        if (is_string($token) && $token !== '' && $this->isApiRequest($url)) {
             $headers[] = "Authorization: Bearer {$token}";
         }
 
         return $headers;
+    }
+
+    private function isApiRequest(string $url): bool
+    {
+        return str_starts_with($url, 'https://api.github.com/');
     }
 
     /**

--- a/src/SelfUpdate/ReleaseClient.php
+++ b/src/SelfUpdate/ReleaseClient.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cpx\SelfUpdate;
+
+use Closure;
+use Cpx\Exceptions\SelfUpdateException;
+
+class ReleaseClient
+{
+    public const LATEST_RELEASE_ENDPOINT = 'https://api.github.com/repos/laravel/cpx/releases/latest';
+
+    public const ASSET_NAME = 'cpx';
+
+    private static ?Closure $fakeLatest = null;
+
+    private static ?Closure $fakeDownload = null;
+
+    public function __construct(private int $timeout = 10)
+    {
+        //
+    }
+
+    /** @throws SelfUpdateException */
+    public function latest(): Release
+    {
+        if (self::$fakeLatest !== null) {
+            return (self::$fakeLatest)();
+        }
+
+        $payload = json_decode($this->httpGet(self::LATEST_RELEASE_ENDPOINT), true);
+
+        if (! is_array($payload) || ! is_string($payload['tag_name'] ?? null)) {
+            throw SelfUpdateException::invalidResponse();
+        }
+
+        [$downloadUrl, $sha256] = $this->pharAsset($payload, $payload['tag_name']);
+
+        return new Release($payload['tag_name'], $downloadUrl, $sha256);
+    }
+
+    /** @throws SelfUpdateException */
+    public function download(Release $release, string $destination): void
+    {
+        if (self::$fakeDownload !== null) {
+            (self::$fakeDownload)($release, $destination);
+
+            return;
+        }
+
+        if (@file_put_contents($destination, $this->httpGet($release->downloadUrl)) === false) {
+            throw SelfUpdateException::unwritableTemporaryFile($destination);
+        }
+    }
+
+    /**
+     * @param  callable(): Release  $latest
+     * @param  (callable(Release, string): void)|null  $download
+     */
+    public static function fake(callable $latest, ?callable $download = null): void
+    {
+        self::$fakeLatest = $latest(...);
+        self::$fakeDownload = $download === null ? null : $download(...);
+    }
+
+    public static function clearFake(): void
+    {
+        self::$fakeLatest = null;
+        self::$fakeDownload = null;
+    }
+
+    /** @throws SelfUpdateException */
+    protected function httpGet(string $url): string
+    {
+        $response = $this->request($url);
+
+        if ($response === null) {
+            throw SelfUpdateException::releaseFetchFailed($url);
+        }
+
+        $status = $response['status'];
+
+        return match (true) {
+            $status >= 200 && $status < 300 => $response['content'],
+            $status === 401 => throw SelfUpdateException::invalidToken(),
+            $status === 403, $status === 429 => throw SelfUpdateException::rateLimited(),
+            default => throw SelfUpdateException::releaseFetchFailed($url, $status),
+        };
+    }
+
+    /** @return array{status: int, content: string}|null */
+    protected function request(string $url): ?array
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'header' => implode("\r\n", $this->requestHeaders($url)),
+                'timeout' => $this->timeout,
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        $stream = @fopen($url, 'r', false, $context);
+
+        if ($stream === false) {
+            return null;
+        }
+
+        $body = stream_get_contents($stream);
+        $headers = stream_get_meta_data($stream)['wrapper_data'] ?? [];
+
+        fclose($stream);
+
+        if ($body === false) {
+            return null;
+        }
+
+        return [
+            'status' => $this->statusCode(is_array($headers) ? $headers : []),
+            'content' => $body,
+        ];
+    }
+
+    /** @return list<string> */
+    protected function requestHeaders(string $url): array
+    {
+        $headers = ['User-Agent: cpx', 'Accept: application/vnd.github+json'];
+
+        $token = $_SERVER['GITHUB_TOKEN'] ?? getenv('GITHUB_TOKEN');
+
+        if (is_string($token) && $token !== '' && str_starts_with($url, 'https://api.github.com/')) {
+            $headers[] = "Authorization: Bearer {$token}";
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{0: string, 1: string|null}
+     *
+     * @throws SelfUpdateException
+     */
+    private function pharAsset(array $payload, string $tag): array
+    {
+        $assets = is_array($payload['assets'] ?? null) ? $payload['assets'] : [];
+
+        foreach ($assets as $asset) {
+            if (! is_array($asset) || ($asset['name'] ?? null) !== self::ASSET_NAME) {
+                continue;
+            }
+
+            $downloadUrl = $asset['browser_download_url'] ?? null;
+
+            if (is_string($downloadUrl) && $downloadUrl !== '') {
+                return [$downloadUrl, $this->sha256Digest($asset)];
+            }
+        }
+
+        throw SelfUpdateException::assetNotFound($tag);
+    }
+
+    /** @param array<string, mixed> $asset */
+    private function sha256Digest(array $asset): ?string
+    {
+        $digest = $asset['digest'] ?? null;
+
+        return is_string($digest) && str_starts_with($digest, 'sha256:')
+            ? substr($digest, strlen('sha256:'))
+            : null;
+    }
+
+    /** @param array<int, mixed> $headers */
+    private function statusCode(array $headers): int
+    {
+        $status = 0;
+
+        // Redirects prepend earlier responses, so the last status line wins.
+        foreach ($headers as $header) {
+            if (is_string($header) && preg_match('~\AHTTP/\S+\s+(\d{3})~', $header, $matches) === 1) {
+                $status = (int) $matches[1];
+            }
+        }
+
+        return $status;
+    }
+}

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -176,6 +176,24 @@ class Filesystem
         self::removeEntry($directory, rmdir: true);
     }
 
+    /** Replace the target with the source; copy when the target cannot be renamed over (a running Windows PHAR). */
+    public static function replaceFile(string $source, string $target, bool $viaCopy = false): void
+    {
+        if ($viaCopy) {
+            if (! @copy($source, $target)) {
+                throw new RuntimeException("Unable to copy {$source} to {$target}.");
+            }
+
+            self::deleteFile($source);
+
+            return;
+        }
+
+        if (! @rename($source, $target)) {
+            throw new RuntimeException("Unable to move {$source} to {$target}.");
+        }
+    }
+
     /** Replace the target with the source, retrying transient Windows file-lock failures. */
     public static function replaceDirectory(string $source, string $target): void
     {

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -184,7 +184,7 @@ class Filesystem
                 throw new RuntimeException("Unable to copy {$source} to {$target}.");
             }
 
-            self::deleteFile($source);
+            @unlink($source);
 
             return;
         }

--- a/tests/Feature/SelfUpdateCommandTest.php
+++ b/tests/Feature/SelfUpdateCommandTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Cpx\Exceptions\SelfUpdateException;
+use Cpx\Runtime\Environment;
+use Cpx\SelfUpdate\Release;
+use Cpx\SelfUpdate\ReleaseClient;
+
+function selfUpdatePhar(string $tag = 'v9.9.9'): string
+{
+    return "<?php echo 'cpx {$tag}';";
+}
+
+function fakeSelfUpdateRelease(string $script, string $tag = 'v9.9.9', ?string $sha256 = null): void
+{
+    ReleaseClient::fake(
+        latest: fn (): Release => new Release(
+            $tag,
+            "https://github.com/laravel/cpx/releases/download/{$tag}/cpx",
+            $sha256 ?? hash('sha256', $script),
+        ),
+        download: function (Release $release, string $destination) use ($script): void {
+            file_put_contents($destination, $script);
+        },
+    );
+}
+
+/**
+ * @param  list<string>  $arguments
+ * @return array{0: int, 1: array<string, mixed>}
+ */
+function runSelfUpdateJson(array $arguments): array
+{
+    [$status, $output] = runCpxCommand($arguments);
+
+    return [$status, json_decode($output, true, 512, JSON_THROW_ON_ERROR)];
+}
+
+test('updates the phar to the latest release', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    $script = selfUpdatePhar();
+    fakeSelfUpdateRelease($script);
+
+    [$status, $output] = runCpxCommand(['self-update']);
+
+    expect($status)->toBe(0)
+        ->and(file_get_contents($target))->toBe($script)
+        ->and($output)->toContain('Updated cpx from dev to v9.9.9.');
+});
+
+test('outputs the update summary as json', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    $script = selfUpdatePhar();
+    fakeSelfUpdateRelease($script);
+
+    [$status, $payload] = runSelfUpdateJson(['self-update', '--json']);
+
+    expect($status)->toBe(0)
+        ->and(file_get_contents($target))->toBe($script)
+        ->and($payload)->toBe([
+            'success' => true,
+            'errors' => [],
+            'summary' => ['updated' => true, 'from' => 'dev', 'to' => 'v9.9.9', 'path' => $target],
+        ]);
+});
+
+test('notes the composer update path for composer-managed installations', function () {
+    $directory = $this->temporaryDirectory().'/vendor/cpx/cpx/builds';
+    mkdir($directory, 0755, true);
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    $script = selfUpdatePhar();
+    fakeSelfUpdateRelease($script);
+
+    [$status, $output] = runCpxCommand(['self-update']);
+
+    expect($status)->toBe(0)
+        ->and(file_get_contents($target))->toBe($script)
+        ->and($output)->toContain("Run 'composer global update cpx/cpx'");
+});
+
+test('reports when cpx is already the latest version', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    ReleaseClient::fake(
+        latest: fn (): Release => new Release('dev', 'https://github.com/laravel/cpx/releases/download/dev/cpx'),
+    );
+
+    [$status, $output] = runCpxCommand(['self-update']);
+
+    expect($status)->toBe(0)
+        ->and(file_get_contents($target))->toBe('old-phar')
+        ->and($output)->toContain('cpx dev is already the latest version.');
+});
+
+test('reports an already up-to-date phar as json', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    ReleaseClient::fake(
+        latest: fn (): Release => new Release('dev', 'https://github.com/laravel/cpx/releases/download/dev/cpx'),
+    );
+
+    [$status, $payload] = runSelfUpdateJson(['self-update', '--json']);
+
+    expect($status)->toBe(0)
+        ->and($payload)->toBe([
+            'success' => true,
+            'errors' => [],
+            'summary' => ['updated' => false, 'version' => 'dev'],
+        ]);
+});
+
+test('fails with guidance when cpx is not running from a phar', function () {
+    $checked = false;
+    ReleaseClient::fake(latest: function () use (&$checked): Release {
+        $checked = true;
+
+        return new Release('v9.9.9', 'https://github.com/laravel/cpx/releases/download/v9.9.9/cpx');
+    });
+
+    [$status, $output] = runCpxCommand(['self-update']);
+
+    expect($status)->toBe(1)
+        ->and($checked)->toBeFalse()
+        ->and($output)->toContain('running as a PHAR')
+        ->and($output)->toContain('composer global update cpx/cpx');
+});
+
+test('renders the failure when the release lookup is rate limited', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    ReleaseClient::fake(latest: fn (): Release => throw SelfUpdateException::rateLimited());
+
+    [$status, $output] = runCpxCommand(['self-update']);
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('GitHub rate limit exceeded')
+        ->and($output)->toContain('GITHUB_TOKEN');
+});
+
+test('outputs the failure as a json envelope', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    ReleaseClient::fake(latest: fn (): Release => throw SelfUpdateException::rateLimited());
+
+    [$status, $payload] = runSelfUpdateJson(['self-update', '--json']);
+
+    expect($status)->toBe(1)
+        ->and($payload)->toBe([
+            'success' => false,
+            'errors' => ['GitHub rate limit exceeded while checking for a new cpx version.'],
+            'summary' => [],
+        ]);
+});
+
+test('keeps the current phar when the checksum does not match', function () {
+    $target = $this->temporaryDirectory().'/cpx';
+    writeExecutable($target, 'old-phar');
+    Environment::fakePharPath($target);
+    fakeSelfUpdateRelease(selfUpdatePhar(), sha256: hash('sha256', 'tampered'));
+
+    [$status, $output] = runCpxCommand(['self-update']);
+
+    expect($status)->toBe(1)
+        ->and(file_get_contents($target))->toBe('old-phar')
+        ->and($output)->toContain('does not match the sha256 checksum');
+});
+
+test('lists self-update as a built-in command', function () {
+    [$status, $output] = runCpxCommand(['list']);
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('self-update');
+});

--- a/tests/Feature/SelfUpdateCommandTest.php
+++ b/tests/Feature/SelfUpdateCommandTest.php
@@ -114,7 +114,7 @@ test('reports an already up-to-date phar as json', function () {
         ->and($payload)->toBe([
             'success' => true,
             'errors' => [],
-            'summary' => ['updated' => false, 'version' => 'dev'],
+            'summary' => ['updated' => false, 'from' => 'dev', 'to' => 'dev', 'path' => $target],
         ]);
 });
 

--- a/tests/Feature/SelfUpdateCommandTest.php
+++ b/tests/Feature/SelfUpdateCommandTest.php
@@ -134,6 +134,21 @@ test('fails with guidance when cpx is not running from a phar', function () {
         ->and($output)->toContain('composer global update cpx/cpx');
 });
 
+test('keeps the failure guidance in the json envelope', function () {
+    [$status, $payload] = runSelfUpdateJson(['self-update', '--json']);
+
+    expect($status)->toBe(1)
+        ->and($payload)->toBe([
+            'success' => false,
+            'errors' => [
+                'self-update is only available when cpx is running as a PHAR.',
+                'Update a Composer-managed installation with:',
+                'composer global update cpx/cpx',
+            ],
+            'summary' => [],
+        ]);
+});
+
 test('renders the failure when the release lookup is rate limited', function () {
     $target = $this->temporaryDirectory().'/cpx';
     writeExecutable($target, 'old-phar');
@@ -158,7 +173,10 @@ test('outputs the failure as a json envelope', function () {
     expect($status)->toBe(1)
         ->and($payload)->toBe([
             'success' => false,
-            'errors' => ['GitHub rate limit exceeded while checking for a new cpx version.'],
+            'errors' => [
+                'GitHub rate limit exceeded while checking for a new cpx version.',
+                'Set the GITHUB_TOKEN environment variable to authenticate and raise the limit.',
+            ],
             'summary' => [],
         ]);
 });

--- a/tests/Feature/SelfUpdateCommandTest.php
+++ b/tests/Feature/SelfUpdateCommandTest.php
@@ -48,7 +48,7 @@ test('updates the phar to the latest release', function () {
 
     expect($status)->toBe(0)
         ->and(file_get_contents($target))->toBe($script)
-        ->and($output)->toContain('Updated cpx from dev to v9.9.9.');
+        ->and(substr_count($output, 'Updated cpx from dev to v9.9.9.'))->toBe(1);
 });
 
 test('outputs the update summary as json', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Cpx\Gists\GistClient;
 use Cpx\Packages\BinExecutable;
 use Cpx\Process\ProcessRunner;
 use Cpx\Runtime\Environment;
+use Cpx\SelfUpdate\ReleaseClient;
 use Cpx\Support\FilesystemFake;
 use Cpx\Support\Interactivity;
 use Laravel\Prompts\Output\BufferedConsoleOutput;
@@ -53,6 +54,7 @@ abstract class TestCase extends BaseTestCase
     {
         ComposerRunner::clearFake();
         GistClient::clearFake();
+        ReleaseClient::clearFake();
         Environment::clearFakePharPath();
         BinExecutable::clearFakeWindows();
         ProcessRunner::clearFake();

--- a/tests/Unit/PharReplacerTest.php
+++ b/tests/Unit/PharReplacerTest.php
@@ -175,9 +175,10 @@ test('restores the backup when the swap fails', function () {
     writeExecutable($target, 'old-phar');
     $script = newPharScript();
 
+    // The faked rename only drives the POSIX branch, so pin the replacer to it.
     FilesystemFake::$failingRenames = 1;
 
-    expect(fn () => quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script))))
+    expect(fn () => quietly(fn () => (new PharReplacer(windows: false))->replace($target, releaseFor($script), writesScript($script))))
         ->toThrow(SelfUpdateException::class, "Unable to replace the cpx PHAR at '{$target}'.")
         ->and(file_get_contents($target))->toBe('old-phar')
         ->and(glob("{$directory}/*"))->toBe([$target]);

--- a/tests/Unit/PharReplacerTest.php
+++ b/tests/Unit/PharReplacerTest.php
@@ -114,6 +114,42 @@ test('throws when the downloaded phar reports the wrong version', function () {
         ->and(file_get_contents($target))->toBe('old-phar');
 });
 
+test('sweeps stale working files from earlier runs', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    file_put_contents("{$target}.".str_repeat('a', 16).'.tmp', 'stale');
+    file_put_contents("{$target}.".str_repeat('b', 16).'.backup', 'stale');
+    file_put_contents("{$target}.keep.tmp", 'not-ours');
+    $script = newPharScript();
+
+    quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script)));
+
+    expect(glob("{$directory}/*"))->toBe([$target, "{$target}.keep.tmp"]);
+});
+
+test('keeps the backup when the restore also fails', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript();
+
+    FilesystemFake::$failingRenames = 1;
+    chmod($target, 0444);
+
+    try {
+        expect(fn () => quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script))))
+            ->toThrow(SelfUpdateException::class, "Unable to replace the cpx PHAR at '{$target}'.");
+    } finally {
+        chmod($target, 0644);
+    }
+
+    $backups = glob("{$directory}/*.backup") ?: [];
+
+    expect($backups)->toHaveCount(1)
+        ->and(file_get_contents($backups[0]))->toBe('old-phar');
+})->skipOnWindows()->skip(function_exists('posix_geteuid') && posix_geteuid() === 0, 'root bypasses file permission checks');
+
 test('throws before downloading when the phar directory is not writable', function () {
     $directory = $this->temporaryDirectory();
     $target = "{$directory}/cpx";
@@ -131,7 +167,7 @@ test('throws before downloading when the phar directory is not writable', functi
     } finally {
         chmod($directory, 0755);
     }
-})->skipOnWindows();
+})->skipOnWindows()->skip(function_exists('posix_geteuid') && posix_geteuid() === 0, 'root bypasses file permission checks');
 
 test('restores the backup when the swap fails', function () {
     $directory = $this->temporaryDirectory();

--- a/tests/Unit/PharReplacerTest.php
+++ b/tests/Unit/PharReplacerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Cpx\Exceptions\SelfUpdateException;
+use Cpx\Process\ProcessRunner;
+use Cpx\SelfUpdate\PharReplacer;
+use Cpx\SelfUpdate\Release;
+use Cpx\Support\FilesystemFake;
+use Cpx\Support\SilentLogger;
+
+function newPharScript(string $tag = 'v9.9.9'): string
+{
+    return "<?php echo 'cpx {$tag}';";
+}
+
+/** Keep the smoke-test child process output off the console, like the commands do. */
+function quietly(Closure $operation): void
+{
+    ProcessRunner::withLogger(new SilentLogger, $operation);
+}
+
+function releaseFor(string $script, string $tag = 'v9.9.9'): Release
+{
+    return new Release($tag, 'https://github.com/laravel/cpx/releases/download/'.$tag.'/cpx', hash('sha256', $script));
+}
+
+function writesScript(string $script): Closure
+{
+    return function (string $destination) use ($script): void {
+        file_put_contents($destination, $script);
+    };
+}
+
+test('replaces the phar and cleans up the working files', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript();
+
+    quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script)));
+
+    expect(file_get_contents($target))->toBe($script)
+        ->and(glob("{$directory}/*"))->toBe([$target]);
+});
+
+test('preserves the executable permissions on the replaced phar', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript();
+
+    quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script)));
+
+    expect(fileperms($target) & 0777)->toBe(0755);
+})->skipOnWindows();
+
+test('replaces via copy in windows mode', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript();
+
+    quietly(fn () => (new PharReplacer(windows: true))->replace($target, releaseFor($script), writesScript($script)));
+
+    expect(file_get_contents($target))->toBe($script)
+        ->and(glob("{$directory}/*"))->toBe([$target]);
+});
+
+test('skips the checksum verification when the release has no digest', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript();
+    $release = new Release('v9.9.9', 'https://github.com/laravel/cpx/releases/download/v9.9.9/cpx');
+
+    quietly(fn () => (new PharReplacer)->replace($target, $release, writesScript($script)));
+
+    expect(file_get_contents($target))->toBe($script);
+});
+
+test('throws when the checksum does not match', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $release = new Release('v9.9.9', 'https://github.com/laravel/cpx/releases/download/v9.9.9/cpx', hash('sha256', 'something-else'));
+
+    expect(fn () => quietly(fn () => (new PharReplacer)->replace($target, $release, writesScript(newPharScript()))))
+        ->toThrow(SelfUpdateException::class, 'The downloaded PHAR does not match the sha256 checksum GitHub published.')
+        ->and(file_get_contents($target))->toBe('old-phar')
+        ->and(glob("{$directory}/*"))->toBe([$target]);
+});
+
+test('throws when the downloaded phar fails to run', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = '<?php exit(1);';
+
+    expect(fn () => quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script))))
+        ->toThrow(SelfUpdateException::class, 'The downloaded PHAR did not report version v9.9.9 when executed.')
+        ->and(file_get_contents($target))->toBe('old-phar')
+        ->and(glob("{$directory}/*"))->toBe([$target]);
+});
+
+test('throws when the downloaded phar reports the wrong version', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript('v0.0.1');
+
+    expect(fn () => quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script, 'v9.9.9'), writesScript($script))))
+        ->toThrow(SelfUpdateException::class, 'The downloaded PHAR did not report version v9.9.9 when executed.')
+        ->and(file_get_contents($target))->toBe('old-phar');
+});
+
+test('throws before downloading when the phar directory is not writable', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    chmod($directory, 0555);
+    $downloaded = false;
+
+    try {
+        expect(function () use ($target, &$downloaded) {
+            (new PharReplacer)->replace($target, releaseFor(newPharScript()), function () use (&$downloaded): void {
+                $downloaded = true;
+            });
+        })->toThrow(SelfUpdateException::class, "The cpx PHAR at '{$target}' cannot be replaced.")
+            ->and($downloaded)->toBeFalse();
+    } finally {
+        chmod($directory, 0755);
+    }
+})->skipOnWindows();
+
+test('restores the backup when the swap fails', function () {
+    $directory = $this->temporaryDirectory();
+    $target = "{$directory}/cpx";
+    writeExecutable($target, 'old-phar');
+    $script = newPharScript();
+
+    FilesystemFake::$failingRenames = 1;
+
+    expect(fn () => quietly(fn () => (new PharReplacer)->replace($target, releaseFor($script), writesScript($script))))
+        ->toThrow(SelfUpdateException::class, "Unable to replace the cpx PHAR at '{$target}'.")
+        ->and(file_get_contents($target))->toBe('old-phar')
+        ->and(glob("{$directory}/*"))->toBe([$target]);
+});

--- a/tests/Unit/ReleaseClientTest.php
+++ b/tests/Unit/ReleaseClientTest.php
@@ -97,7 +97,12 @@ test('latest throws on a malformed response', function (string $body) {
 })->with([
     'not json' => 'not-json',
     'missing tag' => '{"assets": []}',
+    'empty tag' => '{"tag_name": "", "assets": []}',
 ])->throws(SelfUpdateException::class, 'Unexpected response from the GitHub releases API.');
+
+test('latest treats a redirect as a failure instead of following it', function () {
+    respondingReleaseClient(302)->latest();
+})->throws(SelfUpdateException::class, "Unable to fetch the latest cpx release from '".ReleaseClient::LATEST_RELEASE_ENDPOINT."'.");
 
 test('latest throws when the release has no cpx phar asset', function () {
     $client = stubbedReleaseClient([

--- a/tests/Unit/ReleaseClientTest.php
+++ b/tests/Unit/ReleaseClientTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+use Cpx\Exceptions\SelfUpdateException;
+use Cpx\SelfUpdate\Release;
+use Cpx\SelfUpdate\ReleaseClient;
+
+/**
+ * @param  list<array<string, mixed>>  $assets
+ */
+function latestReleasePayload(string $tag = 'v2.1.0', ?array $assets = null): string
+{
+    $assets ??= [
+        ['name' => 'checksums.txt', 'browser_download_url' => 'https://github.com/laravel/cpx/releases/download/v2.1.0/checksums.txt'],
+        [
+            'name' => 'cpx',
+            'browser_download_url' => "https://github.com/laravel/cpx/releases/download/{$tag}/cpx",
+            'digest' => 'sha256:'.str_repeat('ab', 32),
+        ],
+    ];
+
+    return json_encode(['tag_name' => $tag, 'assets' => $assets], JSON_THROW_ON_ERROR);
+}
+
+/** @param array<string, string> $responses */
+function stubbedReleaseClient(array $responses): ReleaseClient
+{
+    return new class($responses) extends ReleaseClient
+    {
+        /** @param array<string, string> $responses */
+        public function __construct(private readonly array $responses) {}
+
+        protected function httpGet(string $url): string
+        {
+            if (! array_key_exists($url, $this->responses)) {
+                throw SelfUpdateException::releaseFetchFailed($url);
+            }
+
+            return $this->responses[$url];
+        }
+    };
+}
+
+function respondingReleaseClient(int $status, string $body = ''): ReleaseClient
+{
+    return new class($status, $body) extends ReleaseClient
+    {
+        public function __construct(private readonly int $status, private readonly string $body) {}
+
+        /** @return array{status: int, content: string} */
+        protected function request(string $url): ?array
+        {
+            return ['status' => $this->status, 'content' => $this->body];
+        }
+    };
+}
+
+test('latest parses the tag, download url, and sha256 digest', function () {
+    $client = stubbedReleaseClient([
+        ReleaseClient::LATEST_RELEASE_ENDPOINT => latestReleasePayload(),
+    ]);
+
+    $release = $client->latest();
+
+    expect($release->tag)->toBe('v2.1.0')
+        ->and($release->downloadUrl)->toBe('https://github.com/laravel/cpx/releases/download/v2.1.0/cpx')
+        ->and($release->sha256)->toBe(str_repeat('ab', 32));
+});
+
+test('latest handles an asset without a sha256 digest', function () {
+    $client = stubbedReleaseClient([
+        ReleaseClient::LATEST_RELEASE_ENDPOINT => latestReleasePayload(assets: [
+            ['name' => 'cpx', 'browser_download_url' => 'https://github.com/laravel/cpx/releases/download/v2.1.0/cpx'],
+        ]),
+    ]);
+
+    expect($client->latest()->sha256)->toBeNull();
+});
+
+test('latest ignores digests that are not sha256', function () {
+    $client = stubbedReleaseClient([
+        ReleaseClient::LATEST_RELEASE_ENDPOINT => latestReleasePayload(assets: [
+            [
+                'name' => 'cpx',
+                'browser_download_url' => 'https://github.com/laravel/cpx/releases/download/v2.1.0/cpx',
+                'digest' => 'sha512:'.str_repeat('cd', 64),
+            ],
+        ]),
+    ]);
+
+    expect($client->latest()->sha256)->toBeNull();
+});
+
+test('latest throws on a malformed response', function (string $body) {
+    stubbedReleaseClient([ReleaseClient::LATEST_RELEASE_ENDPOINT => $body])->latest();
+})->with([
+    'not json' => 'not-json',
+    'missing tag' => '{"assets": []}',
+])->throws(SelfUpdateException::class, 'Unexpected response from the GitHub releases API.');
+
+test('latest throws when the release has no cpx phar asset', function () {
+    $client = stubbedReleaseClient([
+        ReleaseClient::LATEST_RELEASE_ENDPOINT => latestReleasePayload(assets: [
+            ['name' => 'checksums.txt', 'browser_download_url' => 'https://github.com/laravel/cpx/releases/download/v2.1.0/checksums.txt'],
+        ]),
+    ]);
+
+    $client->latest();
+})->throws(SelfUpdateException::class, 'The latest release (v2.1.0) does not include a cpx PHAR asset.');
+
+test('latest throws when the connection fails', function () {
+    $client = new class extends ReleaseClient
+    {
+        protected function request(string $url): ?array
+        {
+            return null;
+        }
+    };
+
+    $client->latest();
+})->throws(SelfUpdateException::class, "Unable to fetch the latest cpx release from '".ReleaseClient::LATEST_RELEASE_ENDPOINT."'.");
+
+test('latest throws an invalid token error when authentication fails', function () {
+    respondingReleaseClient(401, '{"message":"Bad credentials"}')->latest();
+})->throws(SelfUpdateException::class, 'GitHub rejected the provided GITHUB_TOKEN.');
+
+test('latest throws a rate limit error when github rejects the request', function (int $status) {
+    respondingReleaseClient($status, '{"message":"API rate limit exceeded"}')->latest();
+})->with([
+    'forbidden' => 403,
+    'too many requests' => 429,
+])->throws(SelfUpdateException::class, 'GitHub rate limit exceeded while checking for a new cpx version.');
+
+test('latest throws a fetch error on other failure statuses', function () {
+    respondingReleaseClient(500)->latest();
+})->throws(SelfUpdateException::class, "Unable to fetch the latest cpx release from '".ReleaseClient::LATEST_RELEASE_ENDPOINT."'.");
+
+test('download writes the phar to the destination', function () {
+    $release = new Release('v2.1.0', 'https://github.com/laravel/cpx/releases/download/v2.1.0/cpx');
+    $client = stubbedReleaseClient([$release->downloadUrl => 'phar-bytes']);
+    $destination = $this->temporaryDirectory().'/cpx.tmp';
+
+    $client->download($release, $destination);
+
+    expect(file_get_contents($destination))->toBe('phar-bytes');
+});
+
+test('download throws when the destination is not writable', function () {
+    $release = new Release('v2.1.0', 'https://github.com/laravel/cpx/releases/download/v2.1.0/cpx');
+    $client = stubbedReleaseClient([$release->downloadUrl => 'phar-bytes']);
+    $destination = $this->temporaryDirectory().'/missing-directory/cpx.tmp';
+
+    $client->download($release, $destination);
+})->throws(SelfUpdateException::class, 'Unable to write the downloaded PHAR');
+
+test('sends the github token only to the api host', function () {
+    $this->setEnvironmentVariable('GITHUB_TOKEN', 'secret-token');
+
+    $client = new class extends ReleaseClient
+    {
+        /** @return list<string> */
+        public function headers(string $url): array
+        {
+            return $this->requestHeaders($url);
+        }
+    };
+
+    expect($client->headers(ReleaseClient::LATEST_RELEASE_ENDPOINT))->toContain('Authorization: Bearer secret-token')
+        ->and($client->headers('https://github.com/laravel/cpx/releases/download/v2.1.0/cpx'))->not->toContain('Authorization: Bearer secret-token')
+        ->and($client->headers(ReleaseClient::LATEST_RELEASE_ENDPOINT))->toContain('User-Agent: cpx')
+        ->and($client->headers(ReleaseClient::LATEST_RELEASE_ENDPOINT))->toContain('Accept: application/vnd.github+json');
+});
+
+test('fake short-circuits the release lookup and download', function () {
+    $downloaded = null;
+
+    ReleaseClient::fake(
+        latest: fn (): Release => new Release('v9.9.9', 'https://github.com/laravel/cpx/releases/download/v9.9.9/cpx'),
+        download: function (Release $release, string $destination) use (&$downloaded): void {
+            $downloaded = "{$release->tag} -> {$destination}";
+        },
+    );
+
+    $client = new ReleaseClient;
+    $release = $client->latest();
+    $client->download($release, '/tmp/cpx.tmp');
+
+    expect($release->tag)->toBe('v9.9.9')
+        ->and($downloaded)->toBe('v9.9.9 -> /tmp/cpx.tmp');
+});
+
+test('clearFake restores the real lookup path', function () {
+    ReleaseClient::fake(fn (): Release => new Release('v9.9.9', 'https://github.com/laravel/cpx/releases/download/v9.9.9/cpx'));
+    ReleaseClient::clearFake();
+
+    $client = stubbedReleaseClient([ReleaseClient::LATEST_RELEASE_ENDPOINT => latestReleasePayload()]);
+
+    expect($client->latest()->tag)->toBe('v2.1.0');
+});


### PR DESCRIPTION
## Overview

Standalone PHAR users have no way to update cpx short of manually downloading the latest release, while Composer-managed installs already have `composer global update`. This brings the standard self-update experience every PHAR-distributed CLI ships (Composer, Laravel Zero apps) to cpx.

## Solution

`cpx self-update` fetches the latest GitHub release, verifies the downloaded PHAR against the sha256 digest the release API publishes, smoke-runs it with `--version`, and then swaps the running binary in place — an atomic rename on POSIX and a copy-over on Windows, with a backup restored if the swap fails. It follows the house conventions (`--json` envelope, Prompts output, streams-based HTTP with `GITHUB_TOKEN` support) and adds zero runtime dependencies. Composer-managed installs are updated too, with a note that `composer global update cpx/cpx` makes it stick.

## Examples

```
$ cpx self-update

 ┌ cpx updated ─────────────────────────────────────┐
 │ Updated cpx from v1.9.9 to v2.0.0.               │
 └──────────────────────────────────────────────────┘

$ cpx self-update --json
{"success":true,"errors":[],"summary":{"updated":true,"from":"v1.9.9","to":"v2.0.0","path":"/usr/local/bin/cpx"}}
```